### PR TITLE
Standardize docstrings and comments, add type hints, and implement dataclasses

### DIFF
--- a/OpenSTRAN/Coordinates.py
+++ b/OpenSTRAN/Coordinates.py
@@ -41,6 +41,15 @@ class Coordinate():
 
     @classmethod
     def from_tuple(cls, coordinates: tuple[float, float, float]) -> Self:
+        """
+        Create a `Coordinate` instance from a tuple of x, y, z values.
+
+        :param coordinates: A tuple containing (x, y, z) coordinate values.
+        :type coordinates: tuple[float, float, float]
+
+        :returns: A new `Coordinate` instance.
+        :rtype: Self
+        """
         x = coordinates[0]
         y = coordinates[1]
         z = coordinates[2]

--- a/OpenSTRAN/Coordinates.py
+++ b/OpenSTRAN/Coordinates.py
@@ -31,6 +31,12 @@ class Coordinate():
         self.vector = array([self.x, self.y, self.z])
 
     def properties(self) -> dict[str, Any]:
+        """
+        Return the dataclass properties as a dictionary.
+
+        Returns:
+            Dict[str, Any]: Dictionary of this instance's fields.
+        """
         return asdict(self)
 
     @classmethod

--- a/OpenSTRAN/Coordinates.py
+++ b/OpenSTRAN/Coordinates.py
@@ -1,28 +1,28 @@
 from numpy import array
+from dataclasses import dataclass, field
 
 
+@dataclass
 class Coordinate():
     """
-    3D Space Coordinate
+    A class representing a 3D coordinate in space.
 
-    REQUIRED PARAMETERS:
-    x: x coordinate in feet
-    y: y coordinate in feet
-    z: z coordinate in feet
-
-    USAGE:
-    import .Coordinate
-    coordinate = Coordinate(x,y,z)
+    Attributes:
+        x (float): The x-coordinate in feet.
+        y (float): The y-coordinate in feet.
+        z (float): The z-coordinate in feet.
+        coordinates (tuple[float, float, float]): A tuple containing the (x, y, z) coordinates.
+        vector (numpy.ndarray): A numpy array representation of the coordinate vector.
     """
+    x: float
+    y: float
+    z: float
+    coordinates: tuple[float, float, float] = field(init=False)
+    vector: object = field(init=False)
 
-    def __init__(self, x, y, z):
-        # store the x, y, and z coordinates as floating point values
-        self.x = float(x)
-        self.y = float(y)
-        self.z = float(z)
-
-        # store the x, y , and z coordinates as a tuple
+    def __post_init__(self):
+        """
+        Post-initialization method to compute and set the coordinates tuple and vector array.
+        """
         self.coordinates = (self.x, self.y, self.z)
-
-        # store the x, y, and z coordinates as a mathematical point vector
-        self.vector = array([x, y, z])
+        self.vector = array([self.x, self.y, self.z])

--- a/OpenSTRAN/Coordinates.py
+++ b/OpenSTRAN/Coordinates.py
@@ -1,8 +1,11 @@
 from numpy import array
-from dataclasses import dataclass, field
+
+from dataclasses import dataclass, field, asdict
+
+from typing import Self, Any
 
 
-@dataclass
+@dataclass(slots=True)
 class Coordinate():
     """
     A class representing a 3D coordinate in space.
@@ -26,3 +29,13 @@ class Coordinate():
         """
         self.coordinates = (self.x, self.y, self.z)
         self.vector = array([self.x, self.y, self.z])
+
+    def properties(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_tuple(cls, coordinates: tuple[float, float, float]) -> Self:
+        x = coordinates[0]
+        y = coordinates[1]
+        z = coordinates[2]
+        return cls(x, y, z)

--- a/OpenSTRAN/Coordinates.py
+++ b/OpenSTRAN/Coordinates.py
@@ -8,15 +8,18 @@ from typing import Self, Any
 
 @dataclass(slots=True)
 class Coordinate():
-    """
-    A class representing a 3D coordinate in space.
+    """A class representing a 3D coordinate in space.
 
-    Attributes:
-        x (float): The x-coordinate in feet.
-        y (float): The y-coordinate in feet.
-        z (float): The z-coordinate in feet.
-        coordinates (tuple[float, float, float]): A tuple containing the (x, y, z) coordinates.
-        vector (numpy.ndarray): A numpy array representation of the coordinate vector.
+    :ivar x: The x-coordinate in feet
+    :type x: float
+    :ivar y: The y-coordinate in feet
+    :type y: float
+    :ivar z: The z-coordinate in feet
+    :type z: float
+    :ivar coordinates: A tuple containing the (x, y, z) coordinates
+    :type coordinates: tuple[float, float, float]
+    :ivar vector: A numpy array representation of the coordinate vector
+    :type vector: numpy.ndarray
     """
     x: float
     y: float
@@ -32,23 +35,20 @@ class Coordinate():
         self.vector = array([self.x, self.y, self.z])
 
     def properties(self) -> dict[str, Any]:
-        """
-        Return the dataclass properties as a dictionary.
+        """Return the dataclass properties as a dictionary.
 
-        Returns:
-            Dict[str, Any]: Dictionary of this instance's fields.
+        :returns: Dictionary of this instance's fields
+        :rtype: dict[str, Any]
         """
         return asdict(self)
 
     @classmethod
     def from_tuple(cls, coordinates: tuple[float, float, float]) -> Self:
-        """
-        Create a `Coordinate` instance from a tuple of x, y, z values.
+        """Create a Coordinate instance from a tuple of x, y, z values.
 
-        :param coordinates: A tuple containing (x, y, z) coordinate values.
+        :param coordinates: A tuple containing (x, y, z) coordinate values
         :type coordinates: tuple[float, float, float]
-
-        :returns: A new `Coordinate` instance.
+        :returns: A new Coordinate instance
         :rtype: Self
         """
         x = coordinates[0]

--- a/OpenSTRAN/Coordinates.py
+++ b/OpenSTRAN/Coordinates.py
@@ -1,4 +1,5 @@
-from numpy import array
+# import numpy as np
+from numpy import ndarray, array
 
 from dataclasses import dataclass, field, asdict
 
@@ -21,7 +22,7 @@ class Coordinate():
     y: float
     z: float
     coordinates: tuple[float, float, float] = field(init=False)
-    vector: object = field(init=False)
+    vector: ndarray = field(init=False)
 
     def __post_init__(self):
         """

--- a/OpenSTRAN/Member.py
+++ b/OpenSTRAN/Member.py
@@ -78,8 +78,7 @@ class Member():
         default_factory=dict[int, SubMember])
 
     def __post_init__(self) -> None:
-        """
-        Initialize the member after dataclass instantiation.
+        """Initialize the member after dataclass instantiation.
 
         Calculates the member length and discretizes the member into submembers
         based on the specified mesh parameter. Creates connectivity between
@@ -147,17 +146,16 @@ class Member():
                 )
 
     def calculate_length(self, node_i: Node, node_j: Node) -> float:
-        """
-        Calculate the length of the member using the Euclidean distance formula.
+        """Calculate the length of the member using the Euclidean distance formula.
 
         Computes the 3D distance between two nodes based on their coordinate
         positions in the global reference frame.
 
-        :param node_i: Start node of the member.
+        :param node_i: Start node of the member
         :type node_i: Node
-        :param node_j: End node of the member.
+        :param node_j: End node of the member
         :type node_j: Node
-        :returns: The length of the member in inches.
+        :returns: The length of the member in inches
         :rtype: float
         """
         # Calculate the x, y and z vector components of the member
@@ -168,36 +166,34 @@ class Member():
         return (sqrt(dx**2 + dy**2 + dz**2))
 
     def properties(self) -> dict[str, Any]:
-        """
-        Return all member properties as a dictionary.
+        """Return all member properties as a dictionary.
 
         Converts the dataclass instance into a dictionary representation containing
         all field names and their current values.
 
-        :returns: Dictionary containing all member attributes and their values.
+        :returns: Dictionary containing all member attributes and their values
         :rtype: dict[str, Any]
         """
         return asdict(self)
 
     def add_mesh(self, nodes: Nodes, node_i: Node, node_j: Node, mesh: int, l: float) -> list[Node]:
-        """
-        Create intermediate mesh nodes along the member span.
+        """Create intermediate mesh nodes along the member span.
 
         Generates evenly spaced nodes along the member length based on the mesh
         parameter. These nodes are used as intermediary connection points for
         submembers in the discretization process.
 
-        :param nodes: Collection of nodes in the model.
+        :param nodes: Collection of nodes in the model
         :type nodes: Nodes
-        :param node_i: Start node of the member.
+        :param node_i: Start node of the member
         :type node_i: Node
-        :param node_j: End node of the member.
+        :param node_j: End node of the member
         :type node_j: Node
-        :param mesh: Number of equal segments to divide the member into.
+        :param mesh: Number of equal segments to divide the member into
         :type mesh: int
-        :param l: Total length of the member in inches.
+        :param l: Total length of the member in inches
         :type l: float
-        :returns: List of intermediate mesh nodes along the member.
+        :returns: List of intermediate mesh nodes along the member
         :rtype: list[Node]
         """
         # Instantiate an array to hold the mesh nodes
@@ -236,32 +232,31 @@ class Member():
         G: float,
         J: float
     ) -> None:
-        """
-        Add a submember to the member collection.
+        """Add a submember to the member collection.
 
         Creates a new submember element connecting two nodes with specified
         boundary conditions and material properties. The submember is stored
         in the submembers dictionary using an auto-incremented counter.
 
-        :param node_i: Start node of the submember.
+        :param node_i: Start node of the submember
         :type node_i: Node
-        :param node_j: End node of the submember.
+        :param node_j: End node of the submember
         :type node_j: Node
-        :param i_release: Release condition at start node (False = fixed, True = pinned).
+        :param i_release: Release condition at start node (False = fixed, True = pinned)
         :type i_release: bool
-        :param j_release: Release condition at end node (False = fixed, True = pinned).
+        :param j_release: Release condition at end node (False = fixed, True = pinned)
         :type j_release: bool
-        :param E: Young's modulus in ksi.
+        :param E: Young's modulus in ksi
         :type E: float
-        :param Ixx: Strong axis moment of inertia in in^4.
+        :param Ixx: Strong axis moment of inertia in in^4
         :type Ixx: float
-        :param Iyy: Weak axis moment of inertia in in^4.
+        :param Iyy: Weak axis moment of inertia in in^4
         :type Iyy: float
-        :param A: Cross-sectional area in in^2.
+        :param A: Cross-sectional area in in^2
         :type A: float
-        :param G: Shear modulus in ksi.
+        :param G: Shear modulus in ksi
         :type G: float
-        :param J: Polar moment of inertia in in^4.
+        :param J: Polar moment of inertia in in^4
         :type J: float
         :returns: None
         :rtype: None

--- a/OpenSTRAN/Member.py
+++ b/OpenSTRAN/Member.py
@@ -144,7 +144,7 @@ class Member():
 
     def addMesh(self, nodes, node_i, node_j, mesh, l):
         # instantiate an array to hold the mesh nodes
-        meshNodes = []
+        mesh_nodes = []
         # calculate the x, y and z vector components of the member
         dx = node_j.coordinates.x - node_i.coordinates.x
         dy = node_j.coordinates.y - node_i.coordinates.y
@@ -162,9 +162,9 @@ class Member():
             y = node_i.coordinates.y + scalar*y_unit
             z = node_i.coordinates.z + scalar*z_unit
             # add the mesh coordinates as a node to the model
-            meshNodes.append(nodes.addNode(x, y, z, meshNode=True))
+            mesh_nodes.append(nodes.addNode(x, y, z, mesh_node=True))
         # return a list of the mesh nodes
-        return (meshNodes)
+        return (mesh_nodes)
 
     def addSubMember(
         self,

--- a/OpenSTRAN/Members.py
+++ b/OpenSTRAN/Members.py
@@ -9,13 +9,14 @@ from typing import Any
 
 @dataclass(slots=True)
 class Members():
-    """
-    Object that holds the member objects
+    """Container class for managing member (element) objects.
 
-    Attributes:
-        nodes (Nodes): Reference to the global `Nodes` collection.
-        count (int): Number of members added to the collection.
-        members (Dict[int, Member]): Mapping of member id to `Member`.
+    :ivar nodes: Reference to the global Nodes collection
+    :type nodes: Nodes
+    :ivar count: Number of members added to the collection
+    :type count: int
+    :ivar members: Mapping of member ID to Member object
+    :type members: dict[int, Member]
     """
     nodes: Nodes
     count: int = 0
@@ -24,8 +25,8 @@ class Members():
     def properties(self) -> dict[str, Any]:
         """Return the dataclass properties as a dictionary.
 
-        Returns:
-            Dict[str, Any]: Dictionary of this instance's fields.
+        :returns: Dictionary of this instance's fields
+        :rtype: dict[str, Any]
         """
         return asdict(self)
 
@@ -45,42 +46,41 @@ class Members():
         bracing: str = "continuous",
         shape: str = "W12x14",
     ) -> Member:
-        """Method to add member objects to the model.
+        """Add a member to the model.
 
-        :param node_i: Start `Node` of the member.
+        :param node_i: Start node of the member
         :type node_i: Node
-        :param node_j: End `Node` of the member.
+        :param node_j: End node of the member
         :type node_j: Node
-        :param i_release: True if start node is released (pinned).
+        :param i_release: True if start node is released (pinned). Defaults to False.
         :type i_release: bool
-        :param j_release: True if end node is released (pinned).
+        :param j_release: True if end node is released (pinned). Defaults to False.
         :type j_release: bool
-        :param E: Young's Modulus [ksi].
+        :param E: Young's modulus in ksi. Defaults to 29000.0.
         :type E: float
-        :param Ixx: Moment of inertia about the strong axis [in^4].
+        :param Ixx: Moment of inertia about the strong axis in in^4. Defaults to 88.6.
         :type Ixx: float
-        :param Iyy: Moment of inertia about the weak axis [in^4].
+        :param Iyy: Moment of inertia about the weak axis in in^4. Defaults to 2.36.
         :type Iyy: float
-        :param A: Cross-sectional area [in^2].
+        :param A: Cross-sectional area in in^2. Defaults to 4.16.
         :type A: float
-        :param G: Shear Modulus [ksi].
+        :param G: Shear modulus in ksi. Defaults to 12000.0.
         :type G: float
-        :param J: Polar moment of inertia [in^4].
+        :param J: Polar moment of inertia in in^4. Defaults to 0.0704.
         :type J: float
-        :param mesh: Number of discretizations per member.
+        :param mesh: Number of discretizations per member. Defaults to 50.
         :type mesh: int
-        :param bracing: Bracing type (e.g., "continuous").
+        :param bracing: Bracing type (e.g., "continuous"). Defaults to "continuous".
         :type bracing: str
-        :param shape: Section shape name (e.g., "W12x14").
+        :param shape: Section shape name (e.g., "W12x14"). Defaults to "W12x14".
         :type shape: str
-
-        :returns: The created `Member` instance.
+        :returns: The created Member instance
         :rtype: Member
 
-        Usage example::
+        :Example:
 
-            M1 = frame.members.addMember(N1, N2)
-            M2 = frame.members.addMember(N2, N3)
+            >>> M1 = frame.members.addMember(N1, N2)
+            >>> M2 = frame.members.addMember(N2, N3)
         """
         self.count += 1
 

--- a/OpenSTRAN/Members.py
+++ b/OpenSTRAN/Members.py
@@ -1,57 +1,89 @@
 from .Member import Member
-import math
+from .Nodes import Nodes
+from .Node import Node
+
+from dataclasses import dataclass, field, asdict
+
+from typing import Any
 
 
+@dataclass(slots=True)
 class Members():
     """
     Object that holds the member objects
-    """
 
-    def __init__(self, nodes):
-        self.members = {}
-        self.count = 0
-        self.nodes = nodes
+    Attributes:
+        nodes (Nodes): Reference to the global `Nodes` collection.
+        count (int): Number of members added to the collection.
+        members (Dict[int, Member]): Mapping of member id to `Member`.
+    """
+    nodes: Nodes
+    count: int = 0
+    members: dict[int, Member] = field(default_factory=dict[int, Member])
+
+    def properties(self) -> dict[str, Any]:
+        """Return the dataclass properties as a dictionary.
+
+        Returns:
+            Dict[str, Any]: Dictionary of this instance's fields.
+        """
+        return asdict(self)
 
     def addMember(
         self,
-        node_i,
-        node_j,
-        i_release=None,
-        j_release=None,
-        E=None,
-        Ixx=None,
-        Iyy=None,
-        A=None,
-        G=None,
-        J=None,
-        mesh=None,
-        bracing=None,
-        shape=None
-    ):
-        """
-        Method to add member objects to the model
+        node_i: Node,
+        node_j: Node,
+        i_release: bool = False,
+        j_release: bool = False,
+        E: float = 29000.0,
+        Ixx: float = 88.6,
+        Iyy: float = 2.36,
+        A: float = 4.16,
+        G: float = 12000.0,
+        J: float = 0.0704,
+        mesh: int = 50,
+        bracing: str = "continuous",
+        shape: str = "W12x14",
+    ) -> Member:
+        """Method to add member objects to the model.
 
-        REQUIRED PARAMETERS:
-        node_i: OpenStruct.node 3D Space Frame Node Object
-        node_j: OpenStruct.node 3D Space Frame Node Object
+        :param node_i: Start `Node` of the member.
+        :type node_i: Node
+        :param node_j: End `Node` of the member.
+        :type node_j: Node
+        :param i_release: True if start node is released (pinned).
+        :type i_release: bool
+        :param j_release: True if end node is released (pinned).
+        :type j_release: bool
+        :param E: Young's Modulus [ksi].
+        :type E: float
+        :param Ixx: Moment of inertia about the strong axis [in^4].
+        :type Ixx: float
+        :param Iyy: Moment of inertia about the weak axis [in^4].
+        :type Iyy: float
+        :param A: Cross-sectional area [in^2].
+        :type A: float
+        :param G: Shear Modulus [ksi].
+        :type G: float
+        :param J: Polar moment of inertia [in^4].
+        :type J: float
+        :param mesh: Number of discretizations per member.
+        :type mesh: int
+        :param bracing: Bracing type (e.g., "continuous").
+        :type bracing: str
+        :param shape: Section shape name (e.g., "W12x14").
+        :type shape: str
 
-        OPTIONAL PARAMETERS
-        i_release: False = unpinned, True = pinned
-        j_release: False = unpinned, True = pinned
-        E: Young's Modulus [ksi]
-        Izz: Moment of Inertia about the strong axis [in^4]
-        Ixx: Moment of Inertia about the weak axis [in^4]
-        A: Cross-Sectional Area [in^2]
-        G: Shear Modulus [ksi]
-        J: Polar Moment of Inertia [in^4]
-        mesh: number of discretizations per member
+        :returns: The created `Member` instance.
+        :rtype: Member
 
-        USAGE:
-        M1 = frame.members.addMember(N1,N2)
-        M2 = frame.members.addMember(N2,N3)
-        M3 = frame.members.addMember(N3,N4)
+        Usage example::
+
+            M1 = frame.members.addMember(N1, N2)
+            M2 = frame.members.addMember(N2, N3)
         """
         self.count += 1
+
         member = Member(
             self.nodes,
             node_i,
@@ -68,5 +100,6 @@ class Members():
             bracing,
             shape
         )
+
         self.members[self.count] = member
-        return (member)
+        return member

--- a/OpenSTRAN/Node.py
+++ b/OpenSTRAN/Node.py
@@ -1,139 +1,100 @@
+from dataclasses import dataclass, field
+from .Coordinates import Coordinate
+
+
+@dataclass
 class Node():
     """
-    3D Space Frame Node Object
+    A class representing a node in the structural analysis model.
 
-    REQUIRED PARAMETERS:
-
-    coordinates:    (x,y,z)
-    nodeID:            Unique Identifier for the Node
-
-    OPTIONAL PARAMETERS:
-
-    meshNode:    True - The node is part of a member mesh
-                False - Standard node
-
-    restraint = [Ux, Uy, Uz, φx, φy, φz], 0 = 'free', 1 = 'locked'
-
-    plane = 'xy' – defines a model constrained to the X-Y plane
-    plane = 'yz' – defines a model constrained to the Y-Z plane
-    plane = 'xz' – defines a model constrained to the X-Z plane
-
-    DEFAULT PARAMETERS:
-
-    Fx:        Force applied to the node along the x-axis    [kips]
-    Fy:        Force applied to the node along the y-axis    [kips]
-    Fz:        Force applied to the node along the z-axis    [kips]
-    Mx:        Moment applied to the node along the x-axis    [kip-ft]
-    My:        Moment applied to the node along the y-axis    [kip-ft]
-    Mz:        Moment applied to the node along the z-axis    [kip-ft]
-    Ux:        Nodal displacement in the x direction        [ft]
-    Uy:        Nodal displacement in the y direction        [ft]
-    Uz:        Nodal displacement in the z direction        [ft]
-    phi_x:    Nodal rotation in the x direction            [rad]
-    phi_y:    Nodal rotation in the y direction            [rad]
-    phi_z:    Nodal rotation in the z direction            [rad]
-    eFx:    Equivalent nodal force along the x-axis        [kips]
-    eFy:    Equivalent nodal force along the y-axis        [kips]
-    eFz:    Equivalent nodal force along the z-axis        [kips]
-    eMx:    Equivalent nodal moment along the x-axis    [kip-ft]
-    eMy:    Equivalent nodal moment along the y-axis    [kip-ft]
-    eMz:    Equivalent nodal moment along the z-axis    [kip-ft]
+    Attributes:
+        coordinates (Coordinate): The coordinate object defining the node's position.
+        node_ID (int): Unique identifier for the node.
+        mesh_node (bool): Indicates if this is a mesh node. Defaults to False.
+        Fx (float): Applied force in the x-direction in kips. Defaults to 0.0.
+        Fy (float): Applied force in the y-direction in kips. Defaults to 0.0.
+        Fz (float): Applied force in the z-direction in kips. Defaults to 0.0.
+        Mx (float): Applied moment about the x-axis in kip-ft. Defaults to 0.0.
+        My (float): Applied moment about the y-axis in kip-ft. Defaults to 0.0.
+        Mz (float): Applied moment about the z-axis in kip-ft. Defaults to 0.0.
+        Ux (float): Displacement in the x-direction in feet. Defaults to 0.0.
+        Uy (float): Displacement in the y-direction in feet. Defaults to 0.0.
+        Uz (float): Displacement in the z-direction in feet. Defaults to 0.0.
+        phi_x (float): Rotation about the x-axis in radians. Defaults to 0.0.
+        phi_y (float): Rotation about the y-axis in radians. Defaults to 0.0.
+        phi_z (float): Rotation about the z-axis in radians. Defaults to 0.0.
+        eFx (float): Effective force in the x-direction in kips. Defaults to 0.0.
+        eFy (float): Effective force in the y-direction in kips. Defaults to 0.0.
+        eFz (float): Effective force in the z-direction in kips. Defaults to 0.0.
+        eMx (float): Effective moment about the x-axis in kip-ft. Defaults to 0.0.
+        eMy (float): Effective moment about the y-axis in kip-ft. Defaults to 0.0.
+        eMz (float): Effective moment about the z-axis in kip-ft. Defaults to 0.0.
+        Rx (float): Reaction force in the x-direction in kips. Defaults to 0.0.
+        Ry (float): Reaction force in the y-direction in kips. Defaults to 0.0.
+        Rz (float): Reaction force in the z-direction in kips. Defaults to 0.0.
+        Rmx (float): Reaction moment about the x-axis in kip-ft. Defaults to 0.0.
+        Rmy (float): Reaction moment about the y-axis in kip-ft. Defaults to 0.0.
+        Rmz (float): Reaction moment about the z-axis in kip-ft. Defaults to 0.0.
+        plane (str | None): The plane associated with the node. Defaults to None.
+        restraint (List[int]): List of 6 integers indicating restrained degrees of freedom [Ux, Uy, Uz, φx, φy, φz]. Defaults to [0, 0, 0, 0, 0, 0].
     """
+    coordinates: Coordinate
+    node_ID: int
+    mesh_node: bool = False
+    Fx: float = 0.0
+    Fy: float = 0.0
+    Fz: float = 0.0
+    Mx: float = 0.0
+    My: float = 0.0
+    Mz: float = 0.0
+    Ux: float = 0.0
+    Uy: float = 0.0
+    Uz: float = 0.0
+    phi_x: float = 0.0
+    phi_y: float = 0.0
+    phi_z: float = 0.0
+    eFx: float = 0.0
+    eFy: float = 0.0
+    eFz: float = 0.0
+    eMx: float = 0.0
+    eMy: float = 0.0
+    eMz: float = 0.0
+    Rx: float = 0.0
+    Ry: float = 0.0
+    Rz: float = 0.0
+    Rmx: float = 0.0
+    Rmy: float = 0.0
+    Rmz: float = 0.0
+    plane: str | None = None
+    restraint: list[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
 
-    def __init__(
-        self,
-        coordinates,
-        nodeID,
-        meshNode=False,
-        Fx=0.0,
-        Fy=0.0,
-        Fz=0.0,
-        Mx=0.0,
-        My=0.0,
-        Mz=0.0,
-        Ux=0.0,
-        Uy=0.0,
-        Uz=0.0,
-        phi_x=0.0,
-        phi_y=0.0,
-        phi_z=0.0,
-        eFx=0.0,
-        eFy=0.0,
-        eFz=0.0,
-        eMx=0.0,
-        eMy=0.0,
-        eMz=0.0,
-        plane=None,
-        restraint=None
-    ):
-        # coordinates
-        self.coordinates = coordinates
-        # ID
-        self.nodeID = nodeID
-        # True indicates the node is part of a member mesh
-        self.meshNode = meshNode
-        # forces
-        self.Fx = Fx
-        self.Fy = Fy
-        self.Fz = Fz
-        # moments
-        self.Mx = Mx
-        self.My = My
-        self.Mz = Mz
-        # displacements
-        self.Ux = Ux
-        self.Uy = Uy
-        self.Uz = Uz
-        # rotations
-        self.phi_x = phi_x
-        self.phi_y = phi_y
-        self.phi_z = phi_z
-        # equivalent forces
-        self.eFx = eFx
-        self.eFy = eFy
-        self.eFz = eFz
-        # equivalent moments
-        self.eMx = eMx
-        self.eMy = eMy
-        self.eMz = eMz
-        # restraint
-        if plane == None:
-            self.restraint = [0, 0, 0, 0, 0, 0]
-        elif plane == 'xy':
-            self.restraint = [0, 0, 1, 1, 1, 0]
-        elif plane == 'yz':
-            self.restraint = [1, 0, 0, 0, 1, 1]
-        elif plane == 'zx':
-            self.restraint = [0, 1, 0, 1, 0, 1]
-        # nodal reactions
-        self.Rx = 0
-        self.Ry = 0
-        self.Rz = 0
-        self.Rmx = 0
-        self.Rmy = 0
-        self.Rmz = 0
-
-    def addRestraint(self, restraint):
+    def __post_init__(self) -> None:
         """
-        Method to restrain the nodal degrees of freedom
+        Post-initialization method to set default restraints based on the plane.
+        """
+        if self.plane is None:
+            return
+        elif self.plane == 'xy':
+            self.restraint = [0, 0, 1, 1, 1, 0]
+        elif self.plane == 'yz':
+            self.restraint = [1, 0, 0, 0, 1, 1]
+        elif self.plane == 'zx':
+            self.restraint = [0, 1, 0, 1, 0, 1]
 
-        REQUIRED PARAMETERS:
+    def addRestraint(self, restraint: list[int]) -> None:
+        """
+        Adds restraint to the nodal degrees of freedom.
 
-        restraint:    list of 0s and 1s for the various degrees of
-                    freedom, [Ux, Uy, Uz, φx, φy, φz], where non-zero
-                    values are restrained degrees of freedom. For
-                    example, the list to represent a pin would hold
-                    1s for the translational degrees of freedom and
-                    0s for the rotational degrees of freedom.
+        Args:
+            restraint (List[int]): List of 6 integers (0 or 1) indicating which degrees of freedom are restrained.
+                Format: [Ux, Uy, Uz, φx, φy, φz], where 1 means restrained and 0 means free.
+                Examples:
+                - Pinned node: [1, 1, 1, 0, 0, 0]
+                - Fixed node: [1, 1, 1, 1, 1, 1]
+                - Roller in x-direction: [0, 1, 1, 0, 0, 0]
 
-                    pinned node:                [1,1,1,0,0,0]
-                    fixed node:                    [1,1,1,1,1,1]
-                    roller in the x direction:    [0,1,1,0,0,0]
-                    etc.
-
-        USAGE:
-
-        Node.addRestraint([1,1,1,0,0,0])
+        Raises:
+            ValueError: If restraint is not a list of exactly 6 integers, each being 0 or 1.
         """
         # check the user defined list is properly formatted
         if type(restraint) == list and len(restraint) == 6 and restraint == [n for n in restraint if n in [0, 1]]:
@@ -152,11 +113,15 @@ class Node():
                 msg6=str("Roller in the x direction: [0,1,1,0,0,0]")
             ))
 
-    def addLoad(self, mag, lType='moment', direction='y'):
+    def addLoad(self, mag: float, lType: str = 'moment', direction: str = 'y') -> None:
         """
-        lType: type of nodal load moment or point load
-        mag: magnitude of the applied load in kips or kip-ft
-        direction: the local plane in which the load is applied
+        Adds a load to the node.
+
+        Args:
+            mag (float): Magnitude of the load. Units are kips for forces and kip-ft for moments.
+            lType (str): Type of load. Either 'moment' or 'force'. Defaults to 'moment'.
+            direction (str): Direction of the load. 'X', 'Y', or 'Z'. Defaults to 'y'.
+                Note: For moments, the magnitude is multiplied by 12 (converting to inch-kips?).
         """
 
         if lType == 'moment':

--- a/OpenSTRAN/Node.py
+++ b/OpenSTRAN/Node.py
@@ -93,7 +93,7 @@ class Node():
         """
         return asdict(self)
 
-    def addRestraint(self, restraint: list[int]) -> None:
+    def add_restraint(self, restraint: list[int]) -> None:
         """
         Adds restraint to the nodal degrees of freedom.
 
@@ -125,7 +125,7 @@ class Node():
                 msg6=str("Roller in the x direction: [0,1,1,0,0,0]")
             ))
 
-    def addLoad(self, mag: float, lType: str = 'moment', direction: str = 'y') -> None:
+    def add_load(self, mag: float, lType: str = 'moment', direction: str = 'y') -> None:
         """
         Adds a load to the node.
 

--- a/OpenSTRAN/Node.py
+++ b/OpenSTRAN/Node.py
@@ -1,8 +1,11 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
+
 from .Coordinates import Coordinate
 
+from typing import Any
 
-@dataclass
+
+@dataclass(slots=True)
 class Node():
     """
     A class representing a node in the structural analysis model.
@@ -80,6 +83,9 @@ class Node():
             self.restraint = [1, 0, 0, 0, 1, 1]
         elif self.plane == 'zx':
             self.restraint = [0, 1, 0, 1, 0, 1]
+
+    def properties(self) -> dict[str, Any]:
+        return asdict(self)
 
     def addRestraint(self, restraint: list[int]) -> None:
         """

--- a/OpenSTRAN/Node.py
+++ b/OpenSTRAN/Node.py
@@ -85,6 +85,12 @@ class Node():
             self.restraint = [0, 1, 0, 1, 0, 1]
 
     def properties(self) -> dict[str, Any]:
+        """
+        Return the dataclass properties as a dictionary.
+
+        Returns:
+            Dict[str, Any]: Dictionary of this instance's fields.
+        """
         return asdict(self)
 
     def addRestraint(self, restraint: list[int]) -> None:

--- a/OpenSTRAN/Node.py
+++ b/OpenSTRAN/Node.py
@@ -7,39 +7,30 @@ from typing import Any
 
 @dataclass(slots=True)
 class Node():
-    """
-    A class representing a node in the structural analysis model.
+    """A class representing a node in the structural analysis model.
 
-    Attributes:
-        coordinates (Coordinate): The coordinate object defining the node's position.
-        node_ID (int): Unique identifier for the node.
-        mesh_node (bool): Indicates if this is a mesh node. Defaults to False.
-        Fx (float): Applied force in the x-direction in kips. Defaults to 0.0.
-        Fy (float): Applied force in the y-direction in kips. Defaults to 0.0.
-        Fz (float): Applied force in the z-direction in kips. Defaults to 0.0.
-        Mx (float): Applied moment about the x-axis in kip-ft. Defaults to 0.0.
-        My (float): Applied moment about the y-axis in kip-ft. Defaults to 0.0.
-        Mz (float): Applied moment about the z-axis in kip-ft. Defaults to 0.0.
-        Ux (float): Displacement in the x-direction in feet. Defaults to 0.0.
-        Uy (float): Displacement in the y-direction in feet. Defaults to 0.0.
-        Uz (float): Displacement in the z-direction in feet. Defaults to 0.0.
-        phi_x (float): Rotation about the x-axis in radians. Defaults to 0.0.
-        phi_y (float): Rotation about the y-axis in radians. Defaults to 0.0.
-        phi_z (float): Rotation about the z-axis in radians. Defaults to 0.0.
-        eFx (float): Effective force in the x-direction in kips. Defaults to 0.0.
-        eFy (float): Effective force in the y-direction in kips. Defaults to 0.0.
-        eFz (float): Effective force in the z-direction in kips. Defaults to 0.0.
-        eMx (float): Effective moment about the x-axis in kip-ft. Defaults to 0.0.
-        eMy (float): Effective moment about the y-axis in kip-ft. Defaults to 0.0.
-        eMz (float): Effective moment about the z-axis in kip-ft. Defaults to 0.0.
-        Rx (float): Reaction force in the x-direction in kips. Defaults to 0.0.
-        Ry (float): Reaction force in the y-direction in kips. Defaults to 0.0.
-        Rz (float): Reaction force in the z-direction in kips. Defaults to 0.0.
-        Rmx (float): Reaction moment about the x-axis in kip-ft. Defaults to 0.0.
-        Rmy (float): Reaction moment about the y-axis in kip-ft. Defaults to 0.0.
-        Rmz (float): Reaction moment about the z-axis in kip-ft. Defaults to 0.0.
-        plane (str | None): The plane associated with the node. Defaults to None.
-        restraint (List[int]): List of 6 integers indicating restrained degrees of freedom [Ux, Uy, Uz, φx, φy, φz]. Defaults to [0, 0, 0, 0, 0, 0].
+    :ivar coordinates: The coordinate object defining the node's position
+    :type coordinates: Coordinate
+    :ivar node_ID: Unique identifier for the node
+    :type node_ID: int
+    :ivar mesh_node: Indicates if this is a mesh node. Defaults to False
+    :type mesh_node: bool
+    :ivar Fx: Applied force in the x-direction in kips. Defaults to 0.0
+    :type Fx: float
+    :ivar Fy: Applied force in the y-direction in kips. Defaults to 0.0
+    :type Fy: float
+    :ivar Fz: Applied force in the z-direction in kips. Defaults to 0.0
+    :type Fz: float
+    :ivar Mx: Applied moment about the x-axis in kip-ft. Defaults to 0.0
+    :type Mx: float
+    :ivar My: Applied moment about the y-axis in kip-ft. Defaults to 0.0
+    :type My: float
+    :ivar Mz: Applied moment about the z-axis in kip-ft. Defaults to 0.0
+    :type Mz: float
+    :ivar restraint: List of 6 integers indicating restrained degrees of freedom [Ux, Uy, Uz, φx, φy, φz]. Defaults to [0, 0, 0, 0, 0, 0]
+    :type restraint: list[int]
+    :ivar plane: The plane associated with the node. Defaults to None
+    :type plane: str | None
     """
     coordinates: Coordinate
     node_ID: int
@@ -72,8 +63,9 @@ class Node():
     restraint: list[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
 
     def __post_init__(self) -> None:
-        """
-        Post-initialization method to set default restraints based on the plane.
+        """Set default restraints based on the plane constraint.
+
+        If a plane is specified, sets the appropriate out-of-plane restraints.
         """
         if self.plane is None:
             return
@@ -85,28 +77,25 @@ class Node():
             self.restraint = [0, 1, 0, 1, 0, 1]
 
     def properties(self) -> dict[str, Any]:
-        """
-        Return the dataclass properties as a dictionary.
+        """Return the dataclass properties as a dictionary.
 
-        Returns:
-            Dict[str, Any]: Dictionary of this instance's fields.
+        :returns: Dictionary of this instance's fields
+        :rtype: dict[str, Any]
         """
         return asdict(self)
 
     def add_restraint(self, restraint: list[int]) -> None:
-        """
-        Adds restraint to the nodal degrees of freedom.
+        """Add restraint to the nodal degrees of freedom.
 
-        Args:
-            restraint (List[int]): List of 6 integers (0 or 1) indicating which degrees of freedom are restrained.
-                Format: [Ux, Uy, Uz, φx, φy, φz], where 1 means restrained and 0 means free.
-                Examples:
-                - Pinned node: [1, 1, 1, 0, 0, 0]
-                - Fixed node: [1, 1, 1, 1, 1, 1]
-                - Roller in x-direction: [0, 1, 1, 0, 0, 0]
-
-        Raises:
-            ValueError: If restraint is not a list of exactly 6 integers, each being 0 or 1.
+        :param restraint: List of 6 integers (0 or 1) indicating which degrees of freedom are restrained.
+            Format: [Ux, Uy, Uz, φx, φy, φz], where 1 means restrained and 0 means free.
+            Examples:
+            
+            - Pinned node: [1, 1, 1, 0, 0, 0]
+            - Fixed node: [1, 1, 1, 1, 1, 1]
+            - Roller in x-direction: [0, 1, 1, 0, 0, 0]
+        :type restraint: list[int]
+        :raises ValueError: If restraint is not a list of exactly 6 integers, each being 0 or 1
         """
         # check the user defined list is properly formatted
         if type(restraint) == list and len(restraint) == 6 and restraint == [n for n in restraint if n in [0, 1]]:
@@ -126,14 +115,15 @@ class Node():
             ))
 
     def add_load(self, mag: float, lType: str = 'moment', direction: str = 'y') -> None:
-        """
-        Adds a load to the node.
+        """Add a load to the node.
 
-        Args:
-            mag (float): Magnitude of the load. Units are kips for forces and kip-ft for moments.
-            lType (str): Type of load. Either 'moment' or 'force'. Defaults to 'moment'.
-            direction (str): Direction of the load. 'X', 'Y', or 'Z'. Defaults to 'y'.
-                Note: For moments, the magnitude is multiplied by 12 (converting to inch-kips?).
+        :param mag: Magnitude of the load. Units are kips for forces and kip-ft for moments.
+        :type mag: float
+        :param lType: Type of load. Either 'moment' or 'force'. Defaults to 'moment'.
+        :type lType: str
+        :param direction: Direction of the load. 'X', 'Y', or 'Z'. Defaults to 'y'.
+        :type direction: str
+        :note: For moments, the magnitude is multiplied by 12 (kip-in to kip-ft conversion)
         """
 
         if lType == 'moment':

--- a/OpenSTRAN/Nodes.py
+++ b/OpenSTRAN/Nodes.py
@@ -15,7 +15,7 @@ class Nodes():
         self.y = []
         self.z = []
 
-    def addNode(self, x, y, z, meshNode=False):
+    def addNode(self, x, y, z, mesh_node=False):
         """
         Method to add node objects to the model
 
@@ -39,9 +39,9 @@ class Nodes():
             coordinates = Coordinate(x, y, z)
             node = Node(
                 coordinates=coordinates,
-                nodeID=self.count,
+                node_ID=self.count,
                 plane=self.plane,
-                meshNode=meshNode
+                mesh_node=mesh_node
             )
             self.nodes[coordinates] = node
         return (node)

--- a/OpenSTRAN/Nodes.py
+++ b/OpenSTRAN/Nodes.py
@@ -1,75 +1,89 @@
+from dataclasses import dataclass, field
+
 from .Coordinates import Coordinate
 from .Node import Node
 
 
+@dataclass
 class Nodes():
     """
-    Container for user defined node objects
+    A container class for managing user-defined node objects in the structural model.
+
+    Attributes:
+        plane (str or None): The plane associated with the nodes.
+        count (int): The total number of nodes added.
+        nodes (dict[int, Node]): Dictionary mapping node IDs to Node objects.
+        x (list[float]): List of x-coordinates.
+        y (list[float]): List of y-coordinates.
+        z (list[float]): List of z-coordinates.
     """
+    plane: str | None = None
+    count: int = 0
+    nodes: dict[int, Node] = field(default_factory=dict[int, Node])
+    x: list[float] = field(default_factory=list[float])
+    y: list[float] = field(default_factory=list[float])
+    z: list[float] = field(default_factory=list[float])
 
-    def __init__(self, plane=None):
-        self.nodes = {}
-        self.count = 0
-        self.plane = plane
-        self.x = []
-        self.y = []
-        self.z = []
-
-    def addNode(self, x, y, z, mesh_node=False):
+    def addNode(self, x: float, y: float, z: float, mesh_node: bool = False) -> Node:
         """
-        Method to add node objects to the model
+        Add a node to the model at the specified coordinates.
 
-        REQUIRED PARAMETES:
-        x: x coordinate in feet
-        y: y coordinate in feet
-        z: z coordinate in feet
+        Args:
+            x (float): x coordinate in feet
+            y (float): y coordinate in feet
+            z (float): z coordinate in feet
+            mesh_node (bool, optional): Whether this is a mesh node. Defaults to False.
 
-        USAGE:
-        N1 = frame.nodes.addNode(0,0,0)
-        N2 = frame.nodes.addNode(0,10,0)
-        N3 = frame.nodes.addNode(10,10,0)
-        N4 = frame.nodes.addNode(10,0,0)
+        Returns:
+            Node: The added or existing node object.
+
+        Examples:
+            N1 = frame.nodes.addNode(0,0,0)
+            N2 = frame.nodes.addNode(0,10,0)
+            N3 = frame.nodes.addNode(10,10,0)
+            N4 = frame.nodes.addNode(10,0,0)
         """
-        node = self.findNode(x, y, z)
-        if node == None:
+        node: Node | None = self.findNode(x, y, z)
+        if node is None:
             self.count += 1
             self.x.append(x)
             self.y.append(y)
             self.z.append(z)
-            coordinates = Coordinate(x, y, z)
+            coordinates: Coordinate = Coordinate(x, y, z)
             node = Node(
                 coordinates=coordinates,
                 node_ID=self.count,
                 plane=self.plane,
                 mesh_node=mesh_node
             )
-            self.nodes[coordinates] = node
-        return (node)
+            self.nodes[self.count] = node
+        return node
 
-    def findNode(self, x, y, z):
+    def findNode(self, x: float, y: float, z: float) -> Node | None:
         """
-        Method that iterates through the nodes in the model and returns
-        a matching node object for the passed coordinates or a None type
-        object if no matching node is found.
+        Find a node in the model at the specified coordinates.
 
-        REQUIRED PARAMETERS:
-        x: x coordinate in feet
-        y: y coordinate in feet
-        z: z coordinate in feet
+        Args:
+            x (float): x coordinate in feet
+            y (float): y coordinate in feet
+            z (float): z coordinate in feet
+
+        Returns:
+            Node or None: The matching node object if found, None otherwise.
         """
 
         # define a floating point error
-        pointError = 1*10**-10
+        pointError: float = 1*10**-6
 
         # iterate through the model nodes
-        for coordinates, node in self.nodes.items():
-            x_e = coordinates.x
-            y_e = coordinates.y
-            z_e = coordinates.z
+        for node in self.nodes.values():
+            x_e: float = node.coordinates.x
+            y_e: float = node.coordinates.y
+            z_e: float = node.coordinates.z
             if ((x_e - pointError) < x < (x_e + pointError) and (
                 y_e - pointError) < y < (y_e + pointError) and (
                     z_e - pointError) < z < (z_e + pointError)):
-                return (node)
+                return node
             else:
                 continue
-        return (None)
+        return None

--- a/OpenSTRAN/Nodes.py
+++ b/OpenSTRAN/Nodes.py
@@ -27,6 +27,12 @@ class Nodes():
     z: list[float] = field(default_factory=list[float])
 
     def properties(self) -> dict[str, Any]:
+        """
+        Return the dataclass properties as a dictionary.
+
+        Returns:
+            Dict[str, Any]: Dictionary of this instance's fields.
+        """
         return asdict(self)
 
     def addNode(self, x: float, y: float, z: float, mesh_node: bool = False) -> Node:

--- a/OpenSTRAN/Nodes.py
+++ b/OpenSTRAN/Nodes.py
@@ -35,7 +35,7 @@ class Nodes():
         """
         return asdict(self)
 
-    def addNode(self, x: float, y: float, z: float, mesh_node: bool = False) -> Node:
+    def add_node(self, x: float, y: float, z: float, mesh_node: bool = False) -> Node:
         """
         Add a node to the model at the specified coordinates.
 
@@ -49,12 +49,12 @@ class Nodes():
             Node: The added or existing node object.
 
         Examples:
-            N1 = frame.nodes.addNode(0,0,0)
-            N2 = frame.nodes.addNode(0,10,0)
-            N3 = frame.nodes.addNode(10,10,0)
-            N4 = frame.nodes.addNode(10,0,0)
+            N1 = frame.nodes.add_node(0,0,0)
+            N2 = frame.nodes.add_node(0,10,0)
+            N3 = frame.nodes.add_node(10,10,0)
+            N4 = frame.nodes.add_node(10,0,0)
         """
-        node: Node | None = self.findNode(x, y, z)
+        node: Node | None = self.find_node(x, y, z)
         if node is None:
             self.count += 1
             self.x.append(x)
@@ -70,7 +70,7 @@ class Nodes():
             self.nodes[self.count] = node
         return node
 
-    def findNode(self, x: float, y: float, z: float) -> Node | None:
+    def find_node(self, x: float, y: float, z: float) -> Node | None:
         """
         Find a node in the model at the specified coordinates.
 

--- a/OpenSTRAN/Nodes.py
+++ b/OpenSTRAN/Nodes.py
@@ -8,16 +8,20 @@ from typing import Any
 
 @dataclass(slots=True)
 class Nodes():
-    """
-    A container class for managing user-defined node objects in the structural model.
+    """A container class for managing user-defined node objects in the structural model.
 
-    Attributes:
-        plane (str or None): The plane associated with the nodes.
-        count (int): The total number of nodes added.
-        nodes (dict[int, Node]): Dictionary mapping node IDs to Node objects.
-        x (list[float]): List of x-coordinates.
-        y (list[float]): List of y-coordinates.
-        z (list[float]): List of z-coordinates.
+    :ivar plane: The plane constraint associated with the nodes
+    :type plane: str | None
+    :ivar count: The total number of nodes added
+    :type count: int
+    :ivar nodes: Dictionary mapping node IDs to Node objects
+    :type nodes: dict[int, Node]
+    :ivar x: List of x-coordinates
+    :type x: list[float]
+    :ivar y: List of y-coordinates
+    :type y: list[float]
+    :ivar z: List of z-coordinates
+    :type z: list[float]
     """
     plane: str | None = None
     count: int = 0
@@ -27,32 +31,33 @@ class Nodes():
     z: list[float] = field(default_factory=list[float])
 
     def properties(self) -> dict[str, Any]:
-        """
-        Return the dataclass properties as a dictionary.
+        """Return the dataclass properties as a dictionary.
 
-        Returns:
-            Dict[str, Any]: Dictionary of this instance's fields.
+        :returns: Dictionary of this instance's fields
+        :rtype: dict[str, Any]
         """
         return asdict(self)
 
     def add_node(self, x: float, y: float, z: float, mesh_node: bool = False) -> Node:
-        """
-        Add a node to the model at the specified coordinates.
+        """Add a node to the model at the specified coordinates.
 
-        Args:
-            x (float): x coordinate in feet
-            y (float): y coordinate in feet
-            z (float): z coordinate in feet
-            mesh_node (bool, optional): Whether this is a mesh node. Defaults to False.
+        :param x: x-coordinate in feet
+        :type x: float
+        :param y: y-coordinate in feet
+        :type y: float
+        :param z: z-coordinate in feet
+        :type z: float
+        :param mesh_node: Whether this is a mesh node. Defaults to False.
+        :type mesh_node: bool
+        :returns: The added or existing node object
+        :rtype: Node
 
-        Returns:
-            Node: The added or existing node object.
+        :Example:
 
-        Examples:
-            N1 = frame.nodes.add_node(0,0,0)
-            N2 = frame.nodes.add_node(0,10,0)
-            N3 = frame.nodes.add_node(10,10,0)
-            N4 = frame.nodes.add_node(10,0,0)
+            >>> N1 = frame.nodes.add_node(0, 0, 0)
+            >>> N2 = frame.nodes.add_node(0, 10, 0)
+            >>> N3 = frame.nodes.add_node(10, 10, 0)
+            >>> N4 = frame.nodes.add_node(10, 0, 0)
         """
         node: Node | None = self.find_node(x, y, z)
         if node is None:
@@ -71,22 +76,21 @@ class Nodes():
         return node
 
     def find_node(self, x: float, y: float, z: float) -> Node | None:
+        """Find a node in the model at the specified coordinates.
+
+        :param x: x-coordinate in feet
+        :type x: float
+        :param y: y-coordinate in feet
+        :type y: float
+        :param z: z-coordinate in feet
+        :type z: float
+        :returns: The matching node object if found, None otherwise
+        :rtype: Node | None
         """
-        Find a node in the model at the specified coordinates.
-
-        Args:
-            x (float): x coordinate in feet
-            y (float): y coordinate in feet
-            z (float): z coordinate in feet
-
-        Returns:
-            Node or None: The matching node object if found, None otherwise.
-        """
-
-        # define a floating point error
+        # Define a floating point error tolerance.
         pointError: float = 1*10**-6
 
-        # iterate through the model nodes
+        # Iterate through the model nodes.
         for node in self.nodes.values():
             x_e: float = node.coordinates.x
             y_e: float = node.coordinates.y

--- a/OpenSTRAN/Nodes.py
+++ b/OpenSTRAN/Nodes.py
@@ -1,10 +1,12 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 
 from .Coordinates import Coordinate
 from .Node import Node
 
+from typing import Any
 
-@dataclass
+
+@dataclass(slots=True)
 class Nodes():
     """
     A container class for managing user-defined node objects in the structural model.
@@ -23,6 +25,9 @@ class Nodes():
     x: list[float] = field(default_factory=list[float])
     y: list[float] = field(default_factory=list[float])
     z: list[float] = field(default_factory=list[float])
+
+    def properties(self) -> dict[str, Any]:
+        return asdict(self)
 
     def addNode(self, x: float, y: float, z: float, mesh_node: bool = False) -> Node:
         """

--- a/OpenSTRAN/Solver.py
+++ b/OpenSTRAN/Solver.py
@@ -32,20 +32,20 @@ class Solver():
                     continue
 
                 elif submbr.i_release == True and submbr.j_release == False:
-                    self.pinDoF.append(submbr.node_i.nodeID*6-1)
-                    self.pinDoF.append(submbr.node_i.nodeID*6)
+                    self.pinDoF.append(submbr.node_i.node_ID*6-1)
+                    self.pinDoF.append(submbr.node_i.node_ID*6)
 
                 elif submbr.i_release == False and submbr.j_release == True:
-                    self.pinDoF.append(submbr.node_j.nodeID*6-1)
-                    self.pinDoF.append(submbr.node_j.nodeID*6)
+                    self.pinDoF.append(submbr.node_j.node_ID*6-1)
+                    self.pinDoF.append(submbr.node_j.node_ID*6)
 
                 elif submbr.i_release == True and submbr.j_release == True:
-                    self.pinDoF.append(submbr.node_i.nodeID*6-2)
-                    self.pinDoF.append(submbr.node_i.nodeID*6-1)
-                    self.pinDoF.append(submbr.node_i.nodeID*6)
-                    self.pinDoF.append(submbr.node_j.nodeID*6-2)
-                    self.pinDoF.append(submbr.node_j.nodeID*6-1)
-                    self.pinDoF.append(submbr.node_j.nodeID*6)
+                    self.pinDoF.append(submbr.node_i.node_ID*6-2)
+                    self.pinDoF.append(submbr.node_i.node_ID*6-1)
+                    self.pinDoF.append(submbr.node_i.node_ID*6)
+                    self.pinDoF.append(submbr.node_j.node_ID*6-2)
+                    self.pinDoF.append(submbr.node_j.node_ID*6-1)
+                    self.pinDoF.append(submbr.node_j.node_ID*6)
 
         # remove duplicates from the rotational restrained degrees of
         # freedom. Duplicates may exist because a user could potentially
@@ -88,12 +88,12 @@ class Solver():
         # construct the 'Primary Stiffness Matrix' for the structure
         for mbr in members.members.values():
             for submbr in mbr.submembers.values():
-                nodeID_i = submbr.node_i.nodeID
-                nodeID_j = submbr.node_j.nodeID
+                node_ID_i = submbr.node_i.node_ID
+                node_ID_j = submbr.node_j.node_ID
                 i_release = submbr.i_release
                 j_release = submbr.j_release
                 KG = submbr.KG
-                self.AddMemberToKp(nodeID_i, nodeID_j,
+                self.AddMemberToKp(node_ID_i, node_ID_j,
                                    i_release, j_release, KG)
 
         # 'Impose' the influence of supports to produce the
@@ -122,10 +122,10 @@ class Solver():
         for mbr in members.members.values():
             for submbr in mbr.submembers.values():
                 if submbr.i_release == False and submbr.j_release == False:
-                    ia = submbr.node_i.nodeID*6-6
-                    ib = submbr.node_i.nodeID*6-1
-                    ja = submbr.node_j.nodeID*6-6
-                    jb = submbr.node_j.nodeID*6-1
+                    ia = submbr.node_i.node_ID*6-6
+                    ib = submbr.node_i.node_ID*6-1
+                    ja = submbr.node_j.node_ID*6-6
+                    jb = submbr.node_j.node_ID*6-1
 
                     mbrDisplacements = np.array([
                         self.UG[ia, 0],
@@ -158,10 +158,10 @@ class Solver():
                         forces[5], forces[11]]
 
                 elif submbr.i_release == True and submbr.j_release == False:
-                    ia = submbr.node_i.nodeID*6-6
-                    ib = submbr.node_i.nodeID*6-3
-                    ja = submbr.node_j.nodeID*6-6
-                    jb = submbr.node_j.nodeID*6-1
+                    ia = submbr.node_i.node_ID*6-6
+                    ib = submbr.node_i.node_ID*6-3
+                    ja = submbr.node_j.node_ID*6-6
+                    jb = submbr.node_j.node_ID*6-1
 
                     mbrDisplacements = np.array([
                         self.UG[ia, 0],
@@ -190,10 +190,10 @@ class Solver():
                     submbr.results['minor axis moments'] = [0, forces[9]]
 
                 elif submbr.i_release == False and submbr.j_release == True:
-                    ia = submbr.node_i.nodeID*6-6
-                    ib = submbr.node_i.nodeID*6-1
-                    ja = submbr.node_j.nodeID*6-6
-                    jb = submbr.node_j.nodeID*6-3
+                    ia = submbr.node_i.node_ID*6-6
+                    ib = submbr.node_i.node_ID*6-1
+                    ja = submbr.node_j.node_ID*6-6
+                    jb = submbr.node_j.node_ID*6-3
 
                     mbrDisplacements = np.array([
                         self.UG[ia, 0],
@@ -222,10 +222,10 @@ class Solver():
                     submbr.results['minor axis moments'] = [forces[5], 0]
 
                 elif submbr.i_release == True and submbr.j_release == True:
-                    ia = submbr.node_i.nodeID*6-6
-                    ib = submbr.node_i.nodeID*6-3
-                    ja = submbr.node_j.nodeID*6-6
-                    jb = submbr.node_j.nodeID*6-3
+                    ia = submbr.node_i.node_ID*6-6
+                    ib = submbr.node_i.node_ID*6-3
+                    ja = submbr.node_j.node_ID*6-6
+                    jb = submbr.node_j.node_ID*6-3
 
                     mbrDisplacements = np.array([
                         self.UG[ia, 0],
@@ -253,10 +253,10 @@ class Solver():
             for n, submbr in mbr.submembers.items():
 
                 # determine DOFs associated with the submember nodes
-                ia = submbr.node_i.nodeID*6-6
-                ib = submbr.node_i.nodeID*6-1
-                ja = submbr.node_j.nodeID*6-6
-                jb = submbr.node_j.nodeID*6-1
+                ia = submbr.node_i.node_ID*6-6
+                ib = submbr.node_i.node_ID*6-1
+                ja = submbr.node_j.node_ID*6-6
+                jb = submbr.node_j.node_ID*6-1
 
                 # remove influence of equivalent nodal actions from
                 # the Global Force Vector
@@ -309,14 +309,14 @@ class Solver():
                     submbr.ENAs['minor axis moments'][1]
 
                 # store nodal reactions
-                if submbr.node_i.meshNode != True:
+                if submbr.node_i.mesh_node != True:
                     submbr.node_i.Rx = self.FG[ia][0]
                     submbr.node_i.Ry = self.FG[ia+1][0]
                     submbr.node_i.Rz = self.FG[ia+2][0]
                     submbr.node_i.Rmx = self.FG[ia+3][0]
                     submbr.node_i.Rmy = self.FG[ia+4][0]
                     submbr.node_i.Rmz = self.FG[ib][0]
-                elif submbr.node_j.meshNode != True:
+                elif submbr.node_j.mesh_node != True:
                     submbr.node_j.Rx = self.FG[ja][0]
                     submbr.node_j.Ry = self.FG[ja+1][0]
                     submbr.node_j.Rz = self.FG[ja+2][0]
@@ -324,7 +324,7 @@ class Solver():
                     submbr.node_j.Rmy = self.FG[ja+4][0]
                     submbr.node_j.Rmz = self.FG[jb][0]
 
-    def AddMemberToKp(self, nodeID_i, nodeID_j, i_release, j_release, KG):
+    def AddMemberToKp(self, node_ID_i, node_ID_j, i_release, j_release, KG):
 
         if i_release == False and j_release == False:
             K11 = KG[0:6, 0:6]
@@ -332,10 +332,10 @@ class Solver():
             K21 = KG[6:12, 0:6]
             K22 = KG[6:12, 6:12]
 
-            ia = 6*nodeID_i-6
-            ib = 6*nodeID_i-1
-            ja = 6*nodeID_j-6
-            jb = 6*nodeID_j-1
+            ia = 6*node_ID_i-6
+            ib = 6*node_ID_i-1
+            ja = 6*node_ID_j-6
+            jb = 6*node_ID_j-1
 
         elif i_release == True and j_release == False:
             K11 = KG[0:4, 0:4]
@@ -343,10 +343,10 @@ class Solver():
             K21 = KG[4:10, 0:4]
             K22 = KG[4:10, 4:10]
 
-            ia = 6*nodeID_i-6
-            ib = 6*nodeID_i-3
-            ja = 6*nodeID_j-6
-            jb = 6*nodeID_j-1
+            ia = 6*node_ID_i-6
+            ib = 6*node_ID_i-3
+            ja = 6*node_ID_j-6
+            jb = 6*node_ID_j-1
 
         elif i_release == False and j_release == True:
             K11 = KG[0:6, 0:6]
@@ -354,10 +354,10 @@ class Solver():
             K21 = KG[6:10, 0:6]
             K22 = KG[6:10, 6:10]
 
-            ia = 6*nodeID_i-6
-            ib = 6*nodeID_i-1
-            ja = 6*nodeID_j-6
-            jb = 6*nodeID_j-3
+            ia = 6*node_ID_i-6
+            ib = 6*node_ID_i-1
+            ja = 6*node_ID_j-6
+            jb = 6*node_ID_j-3
 
         elif i_release == True and j_release == True:
             K11 = KG[0:3, 0:3]
@@ -365,10 +365,10 @@ class Solver():
             K21 = KG[3:6, 0:3]
             K22 = KG[3:6, 3:6]
 
-            ia = 6*nodeID_i-6
-            ib = 6*nodeID_i-4
-            ja = 6*nodeID_j-6
-            jb = 6*nodeID_j-4
+            ia = 6*node_ID_i-6
+            ib = 6*node_ID_i-4
+            ja = 6*node_ID_j-6
+            jb = 6*node_ID_j-4
 
         self.Kp[ia:ib+1, ia:ib+1] = self.Kp[ia:ib+1, ia:ib+1] + K11
         self.Kp[ia:ib+1, ja:jb+1] = self.Kp[ia:ib+1, ja:jb+1] + K12

--- a/OpenSTRAN/Solver.py
+++ b/OpenSTRAN/Solver.py
@@ -1,29 +1,72 @@
+from .Nodes import Nodes
+from .Members import Members
+
 import numpy as np
 
 
 class Solver():
+    """Solver class for structural finite element analysis.
+
+    This class performs finite element analysis on structural models by assembling
+    the global stiffness matrix, applying boundary conditions, and solving for nodal
+    displacements and member forces.
+
+    :ivar nDoF: Total number of degrees of freedom in the structure
+    :type nDoF: int
+    :ivar pinDoF: List of pinned (rotational) degrees of freedom indices
+    :type pinDoF: list[int]
+    :ivar restrainedDoF: List of restrained degrees of freedom indices
+    :type restrainedDoF: list[int]
+    :ivar Kp: Primary stiffness matrix for the structure
+    :type Kp: numpy.ndarray | None
+    :ivar force_vector: Global force vector with applied loads
+    :type force_vector: numpy.ndarray | None
+    :ivar global_displacement_vector: Global displacement vector at all nodes
+    :type global_displacement_vector: numpy.ndarray | None
+    :ivar global_force_vector: Global reaction force vector
+    :type global_force_vector: numpy.ndarray | None
     """
-    docstring for Solver
-    """
 
-    def __init__(self):
-        self.nDoF = 0
-        self.pinDoF = []
+    def __init__(self) -> None:
+        """Initialize the Solver with empty attributes.
+
+        Sets up the solver with default values for the stiffness matrix,
+        degrees of freedom tracking, and solution vectors.
+        """
+        self.nDoF: int = 0
+        self.pinDoF: list[int] = []
+        self.restrainedDoF: list[int] = []
+        self.Kp: np.ndarray | None = None
+        # self.restrainedIndex: list[int] = []
+        self.force_vector: np.ndarray | None = None
+        self.global_displacement_vector: np.ndarray | None = None
+        self.global_force_vector: np.ndarray | None = None
+
+    def solve(self, nodes: Nodes, members: Members) -> None:
+        """Solve the structural system for displacements and member forces.
+
+        This method performs a complete finite element analysis including:
+        
+        - Assembly of the global stiffness matrix
+        - Application of boundary conditions
+        - Solution for nodal displacements using matrix reduction
+        - Computation of member forces and reactions
+        - Removal of equivalent nodal actions (distributed loads)
+
+        :param nodes: Collection of nodes in the structural model
+        :type nodes: Nodes
+        :param members: Collection of members in the structural model
+        :type members: Members
+        :returns: None
+        :rtype: None
+        """
+        # Re-instantiate empty arrays for second-order analysis.
         self.restrainedDoF = []
-        self.Kp = None
-        # self.restrainedIndex = []
-        self.forceVector = None
-        self.UG = None
-        self.FG = None
 
-    def solve(self, nodes, members):
-        # reinstantiate empty arrays for second order analylsis
-        self.restrainedDoF = []
-
-        # determine the total degrees of freedom for the model
+        # Determine the total degrees of freedom for the model.
         self.nDoF = nodes.count*6
 
-        # determine the rotational restrained degrees of freedom
+        # Determine the rotational restrained degrees of freedom.
         for mbr in members.members.values():
 
             for submbr in mbr.submembers.values():
@@ -47,15 +90,15 @@ class Solver():
                     self.pinDoF.append(submbr.node_j.node_ID*6-1)
                     self.pinDoF.append(submbr.node_j.node_ID*6)
 
-        # remove duplicates from the rotational restrained degrees of
-        # freedom. Duplicates may exist because a user could potentially
-        # define an i and j release on each side of a single node
+        # Remove duplicates from the rotational restrained degrees of freedom.
+        # Duplicates may exist because a user could potentially define
+        # an i and j release on each side of a single node.
         self.pinDoF = list(dict.fromkeys(self.pinDoF))
 
-        # instantiate the Primary Stiffness Matrix
+        # Instantiate the primary stiffness matrix.
         self.Kp = np.zeros([self.nDoF, self.nDoF])
 
-        # instantiate a list of the restrained degrees of freedom
+        # Instantiate a list of the restrained degrees of freedom.
         for i, node in enumerate(nodes.nodes.items()):
             if node[1].restraint == [0, 0, 0, 0, 0, 0]:
                 continue
@@ -64,28 +107,28 @@ class Solver():
                     if DoF == 1:
                         self.restrainedDoF.append(i*6 + n)
 
-        # check pins to see if attached members contribute to stiffness
+        # Check pins to see if attached members contribute to stiffness.
         for DoF in [x-1 for x in self.pinDoF]:
             if (np.sum(self.Kp[DoF, :]) < 1*10**-6):
                 self.restrainedDoF.append(DoF)
 
-        # remove duplicates from restrained degrees of freedom
+        # Remove duplicates from restrained degrees of freedom.
         self.restrainedDoF = list(dict.fromkeys(self.restrainedDoF))
 
-        # sort the restrained degrees of freedom in ascending order
+        # Sort the restrained degrees of freedom in ascending order.
         self.restrainedDoF.sort()
 
-        # instantiate the force vector
-        self.forceVector = np.zeros((self.nDoF, 1))
+        # Instantiate the force vector.
+        self.force_vector = np.zeros((self.nDoF, 1))
         for i, node in enumerate(nodes.nodes.items()):
-            self.forceVector[i*6][0] = node[1].Fx
-            self.forceVector[i*6 + 1][0] = node[1].Fy
-            self.forceVector[i*6 + 2][0] = node[1].Fz
-            self.forceVector[i*6 + 3][0] = node[1].Mx
-            self.forceVector[i*6 + 4][0] = node[1].My
-            self.forceVector[i*6 + 5][0] = node[1].Mz
+            self.force_vector[i*6][0] = node[1].Fx
+            self.force_vector[i*6 + 1][0] = node[1].Fy
+            self.force_vector[i*6 + 2][0] = node[1].Fz
+            self.force_vector[i*6 + 3][0] = node[1].Mx
+            self.force_vector[i*6 + 4][0] = node[1].My
+            self.force_vector[i*6 + 5][0] = node[1].Mz
 
-        # construct the 'Primary Stiffness Matrix' for the structure
+        # Construct the primary stiffness matrix for the structure.
         for mbr in members.members.values():
             for submbr in mbr.submembers.values():
                 node_ID_i = submbr.node_i.node_ID
@@ -96,29 +139,32 @@ class Solver():
                 self.AddMemberToKp(node_ID_i, node_ID_j,
                                    i_release, j_release, KG)
 
-        # 'Impose' the influence of supports to produce the
-        # 'Structure Stiffness Matrix'
+        # Impose the influence of supports to produce the structure stiffness matrix.
         self.Ks = np.delete(self.Kp, self.restrainedDoF, 0)
         self.Ks = np.delete(self.Ks, self.restrainedDoF, 1)
         self.Ks = np.matrix(self.Ks)
 
-        # solve for unknown displacements
-        reducedForceVector = np.delete(self.forceVector, self.restrainedDoF, 0)
+        # Solve for unknown displacements.
+        reducedForceVector = np.delete(
+            self.force_vector, self.restrainedDoF, 0)
 
         U = np.linalg.solve(self.Ks, reducedForceVector)
-        self.UG = np.zeros([self.nDoF, 1])
+        self.global_displacement_vector = np.zeros([self.nDoF, 1])
+        assert self.global_displacement_vector is not None
         index = 0
         for i in range(self.nDoF):
             if i in self.restrainedDoF:
                 continue
             else:
-                self.UG[i] = U[index]
+                self.global_displacement_vector[i] = U[index]
                 index += 1
 
-        # back substitute displacements to calculate reaction forces
-        self.FG = np.matmul(self.Kp, self.UG)
+        # Back-substitute displacements to calculate reaction forces.
+        self.global_force_vector = np.matmul(
+            self.Kp, self.global_displacement_vector)
+        assert self.global_force_vector is not None
 
-        # use nodal displacements to determine member forces
+        # Use nodal displacements to determine member forces.
         for mbr in members.members.values():
             for submbr in mbr.submembers.values():
                 if submbr.i_release == False and submbr.j_release == False:
@@ -128,18 +174,18 @@ class Solver():
                     jb = submbr.node_j.node_ID*6-1
 
                     mbrDisplacements = np.array([
-                        self.UG[ia, 0],
-                        self.UG[ia+1, 0],
-                        self.UG[ia+2, 0],
-                        self.UG[ia+3, 0],
-                        self.UG[ia+4, 0],
-                        self.UG[ib, 0],
-                        self.UG[ja, 0],
-                        self.UG[ja+1, 0],
-                        self.UG[ja+2, 0],
-                        self.UG[ja+3, 0],
-                        self.UG[ja+4, 0],
-                        self.UG[jb, 0]
+                        self.global_displacement_vector[ia, 0],
+                        self.global_displacement_vector[ia+1, 0],
+                        self.global_displacement_vector[ia+2, 0],
+                        self.global_displacement_vector[ia+3, 0],
+                        self.global_displacement_vector[ia+4, 0],
+                        self.global_displacement_vector[ib, 0],
+                        self.global_displacement_vector[ja, 0],
+                        self.global_displacement_vector[ja+1, 0],
+                        self.global_displacement_vector[ja+2, 0],
+                        self.global_displacement_vector[ja+3, 0],
+                        self.global_displacement_vector[ja+4, 0],
+                        self.global_displacement_vector[jb, 0]
                     ]).T
 
                     submbr.results['displacements'] = np.matmul(
@@ -164,16 +210,16 @@ class Solver():
                     jb = submbr.node_j.node_ID*6-1
 
                     mbrDisplacements = np.array([
-                        self.UG[ia, 0],
-                        self.UG[ia+1, 0],
-                        self.UG[ia+2, 0],
-                        self.UG[ib, 0],
-                        self.UG[ja, 0],
-                        self.UG[ja+1, 0],
-                        self.UG[ja+2, 0],
-                        self.UG[ja+3, 0],
-                        self.UG[ja+4, 0],
-                        self.UG[jb, 0]
+                        self.global_displacement_vector[ia, 0],
+                        self.global_displacement_vector[ia+1, 0],
+                        self.global_displacement_vector[ia+2, 0],
+                        self.global_displacement_vector[ib, 0],
+                        self.global_displacement_vector[ja, 0],
+                        self.global_displacement_vector[ja+1, 0],
+                        self.global_displacement_vector[ja+2, 0],
+                        self.global_displacement_vector[ja+3, 0],
+                        self.global_displacement_vector[ja+4, 0],
+                        self.global_displacement_vector[jb, 0]
                     ]).T
 
                     submbr.results['displacements'] = np.matmul(
@@ -196,16 +242,16 @@ class Solver():
                     jb = submbr.node_j.node_ID*6-3
 
                     mbrDisplacements = np.array([
-                        self.UG[ia, 0],
-                        self.UG[ia+1, 0],
-                        self.UG[ia+2, 0],
-                        self.UG[ia+3, 0],
-                        self.UG[ia+4, 0],
-                        self.UG[ib, 0],
-                        self.UG[ja, 0],
-                        self.UG[ja+1, 0],
-                        self.UG[ja+2, 0],
-                        self.UG[jb, 0]
+                        self.global_displacement_vector[ia, 0],
+                        self.global_displacement_vector[ia+1, 0],
+                        self.global_displacement_vector[ia+2, 0],
+                        self.global_displacement_vector[ia+3, 0],
+                        self.global_displacement_vector[ia+4, 0],
+                        self.global_displacement_vector[ib, 0],
+                        self.global_displacement_vector[ja, 0],
+                        self.global_displacement_vector[ja+1, 0],
+                        self.global_displacement_vector[ja+2, 0],
+                        self.global_displacement_vector[jb, 0]
                     ]).T
 
                     submbr.results['displacements'] = np.matmul(
@@ -228,12 +274,12 @@ class Solver():
                     jb = submbr.node_j.node_ID*6-3
 
                     mbrDisplacements = np.array([
-                        self.UG[ia, 0],
-                        self.UG[ia+1, 0],
-                        self.UG[ib, 0],
-                        self.UG[ja, 0],
-                        self.UG[ja+1, 0],
-                        self.UG[jb, 0]
+                        self.global_displacement_vector[ia, 0],
+                        self.global_displacement_vector[ia+1, 0],
+                        self.global_displacement_vector[ib, 0],
+                        self.global_displacement_vector[ja, 0],
+                        self.global_displacement_vector[ja+1, 0],
+                        self.global_displacement_vector[jb, 0]
                     ]).T
 
                     submbr.results['displacements'] = np.matmul(
@@ -248,35 +294,45 @@ class Solver():
                     submbr.results['major axis moments'] = [0, 0]
                     submbr.results['minor axis moments'] = [0, 0]
 
-        # remove the influence of equivalent nodal actions
+        # Remove the influence of equivalent nodal actions.
         for mbr in members.members.values():
             for n, submbr in mbr.submembers.items():
 
-                # determine DOFs associated with the submember nodes
+                # Determine DOFs associated with the submember nodes.
                 ia = submbr.node_i.node_ID*6-6
                 ib = submbr.node_i.node_ID*6-1
                 ja = submbr.node_j.node_ID*6-6
                 jb = submbr.node_j.node_ID*6-1
 
-                # remove influence of equivalent nodal actions from
-                # the Global Force Vector
+                # Remove influence of equivalent nodal actions from the global force vector.
 
-                self.FG[ia] = self.FG[ia] - submbr.node_i.eFx
-                self.FG[ia+1] = self.FG[ia+1] - submbr.node_i.eFy
-                self.FG[ia+2] = self.FG[ia+2] - submbr.node_i.eFz
-                self.FG[ia+3] = self.FG[ia+3] - submbr.node_i.eMx
-                self.FG[ia+4] = self.FG[ia+4] - submbr.node_i.eMy
-                self.FG[ib] = self.FG[ib] - submbr.node_i.eMz
+                self.global_force_vector[ia] = self.global_force_vector[ia] - \
+                    submbr.node_i.eFx
+                self.global_force_vector[ia +
+                                         1] = self.global_force_vector[ia+1] - submbr.node_i.eFy
+                self.global_force_vector[ia +
+                                         2] = self.global_force_vector[ia+2] - submbr.node_i.eFz
+                self.global_force_vector[ia +
+                                         3] = self.global_force_vector[ia+3] - submbr.node_i.eMx
+                self.global_force_vector[ia +
+                                         4] = self.global_force_vector[ia+4] - submbr.node_i.eMy
+                self.global_force_vector[ib] = self.global_force_vector[ib] - \
+                    submbr.node_i.eMz
 
-                self.FG[ja] = self.FG[ja] - submbr.node_j.eFx
-                self.FG[ja+1] = self.FG[ja+1] - submbr.node_j.eFy
-                self.FG[ja+2] = self.FG[ja+2] - submbr.node_j.eFz
-                self.FG[ja+3] = self.FG[ja+3] - submbr.node_j.eMx
-                self.FG[ja+4] = self.FG[ja+4] - submbr.node_j.eMy
-                self.FG[jb] = self.FG[jb] - submbr.node_j.eMz
+                self.global_force_vector[ja] = self.global_force_vector[ja] - \
+                    submbr.node_j.eFx
+                self.global_force_vector[ja +
+                                         1] = self.global_force_vector[ja+1] - submbr.node_j.eFy
+                self.global_force_vector[ja +
+                                         2] = self.global_force_vector[ja+2] - submbr.node_j.eFz
+                self.global_force_vector[ja +
+                                         3] = self.global_force_vector[ja+3] - submbr.node_j.eMx
+                self.global_force_vector[ja +
+                                         4] = self.global_force_vector[ja+4] - submbr.node_j.eMy
+                self.global_force_vector[jb] = self.global_force_vector[jb] - \
+                    submbr.node_j.eMz
 
-                # remove influence of equivalent nodal actions from
-                # the member forces
+                # Remove influence of equivalent nodal actions from member forces.
 
                 submbr.results['axial'][0] = submbr.results['axial'][0] - \
                     submbr.ENAs['axial'][0]
@@ -308,29 +364,49 @@ class Solver():
                 submbr.results['minor axis moments'][1] = submbr.results['minor axis moments'][1] - \
                     submbr.ENAs['minor axis moments'][1]
 
-                # store nodal reactions
+                # Store nodal reactions.
                 if submbr.node_i.mesh_node != True:
-                    submbr.node_i.Rx = self.FG[ia][0]
-                    submbr.node_i.Ry = self.FG[ia+1][0]
-                    submbr.node_i.Rz = self.FG[ia+2][0]
-                    submbr.node_i.Rmx = self.FG[ia+3][0]
-                    submbr.node_i.Rmy = self.FG[ia+4][0]
-                    submbr.node_i.Rmz = self.FG[ib][0]
+                    submbr.node_i.Rx = self.global_force_vector[ia][0]
+                    submbr.node_i.Ry = self.global_force_vector[ia+1][0]
+                    submbr.node_i.Rz = self.global_force_vector[ia+2][0]
+                    submbr.node_i.Rmx = self.global_force_vector[ia+3][0]
+                    submbr.node_i.Rmy = self.global_force_vector[ia+4][0]
+                    submbr.node_i.Rmz = self.global_force_vector[ib][0]
                 elif submbr.node_j.mesh_node != True:
-                    submbr.node_j.Rx = self.FG[ja][0]
-                    submbr.node_j.Ry = self.FG[ja+1][0]
-                    submbr.node_j.Rz = self.FG[ja+2][0]
-                    submbr.node_j.Rmx = self.FG[ja+3][0]
-                    submbr.node_j.Rmy = self.FG[ja+4][0]
-                    submbr.node_j.Rmz = self.FG[jb][0]
+                    submbr.node_j.Rx = self.global_force_vector[ja][0]
+                    submbr.node_j.Ry = self.global_force_vector[ja+1][0]
+                    submbr.node_j.Rz = self.global_force_vector[ja+2][0]
+                    submbr.node_j.Rmx = self.global_force_vector[ja+3][0]
+                    submbr.node_j.Rmy = self.global_force_vector[ja+4][0]
+                    submbr.node_j.Rmz = self.global_force_vector[jb][0]
 
-    def AddMemberToKp(self, node_ID_i, node_ID_j, i_release, j_release, KG):
+    def AddMemberToKp(self, node_ID_i: int, node_ID_j: int, i_release: bool, j_release: bool, KG: np.ndarray) -> None:
+        """Add member stiffness contributions to the global stiffness matrix.
+
+        Extracts the appropriate submatrix from the member's global stiffness matrix
+        based on end releases and assembles it into the primary stiffness matrix at
+        the correct locations corresponding to the member's nodes.
+
+        :param node_ID_i: Node ID at the start of the member
+        :type node_ID_i: int
+        :param node_ID_j: Node ID at the end of the member
+        :type node_ID_j: int
+        :param i_release: Whether the i-node has rotational releases (pinned)
+        :type i_release: bool
+        :param j_release: Whether the j-node has rotational releases (pinned)
+        :type j_release: bool
+        :param KG: Global stiffness matrix of the member (12x12 or reduced)
+        :type KG: numpy.ndarray
+        :returns: None
+        :rtype: None
+        """
+        assert self.Kp is not None
 
         if i_release == False and j_release == False:
-            K11 = KG[0:6, 0:6]
-            K12 = KG[0:6, 6:12]
-            K21 = KG[6:12, 0:6]
-            K22 = KG[6:12, 6:12]
+            k11 = KG[0:6, 0:6]
+            k12 = KG[0:6, 6:12]
+            k21 = KG[6:12, 0:6]
+            k22 = KG[6:12, 6:12]
 
             ia = 6*node_ID_i-6
             ib = 6*node_ID_i-1
@@ -338,10 +414,10 @@ class Solver():
             jb = 6*node_ID_j-1
 
         elif i_release == True and j_release == False:
-            K11 = KG[0:4, 0:4]
-            K12 = KG[0:4, 4:10]
-            K21 = KG[4:10, 0:4]
-            K22 = KG[4:10, 4:10]
+            k11 = KG[0:4, 0:4]
+            k12 = KG[0:4, 4:10]
+            k21 = KG[4:10, 0:4]
+            k22 = KG[4:10, 4:10]
 
             ia = 6*node_ID_i-6
             ib = 6*node_ID_i-3
@@ -349,10 +425,10 @@ class Solver():
             jb = 6*node_ID_j-1
 
         elif i_release == False and j_release == True:
-            K11 = KG[0:6, 0:6]
-            K12 = KG[0:6, 6:10]
-            K21 = KG[6:10, 0:6]
-            K22 = KG[6:10, 6:10]
+            k11 = KG[0:6, 0:6]
+            k12 = KG[0:6, 6:10]
+            k21 = KG[6:10, 0:6]
+            k22 = KG[6:10, 6:10]
 
             ia = 6*node_ID_i-6
             ib = 6*node_ID_i-1
@@ -360,17 +436,22 @@ class Solver():
             jb = 6*node_ID_j-3
 
         elif i_release == True and j_release == True:
-            K11 = KG[0:3, 0:3]
-            K12 = KG[0:3, 3:6]
-            K21 = KG[3:6, 0:3]
-            K22 = KG[3:6, 3:6]
+            k11 = KG[0:3, 0:3]
+            k12 = KG[0:3, 3:6]
+            k21 = KG[3:6, 0:3]
+            k22 = KG[3:6, 3:6]
 
             ia = 6*node_ID_i-6
             ib = 6*node_ID_i-4
             ja = 6*node_ID_j-6
             jb = 6*node_ID_j-4
 
-        self.Kp[ia:ib+1, ia:ib+1] = self.Kp[ia:ib+1, ia:ib+1] + K11
-        self.Kp[ia:ib+1, ja:jb+1] = self.Kp[ia:ib+1, ja:jb+1] + K12
-        self.Kp[ja:jb+1, ia:ib+1] = self.Kp[ja:jb+1, ia:ib+1] + K21
-        self.Kp[ja:jb+1, ja:jb+1] = self.Kp[ja:jb+1, ja:jb+1] + K22
+        else:
+            raise ValueError(
+                "Member boundary conditions must be pinned or fixed"
+            )
+
+        self.Kp[ia:ib+1, ia:ib+1] = self.Kp[ia:ib+1, ia:ib+1] + k11
+        self.Kp[ia:ib+1, ja:jb+1] = self.Kp[ia:ib+1, ja:jb+1] + k12
+        self.Kp[ja:jb+1, ia:ib+1] = self.Kp[ja:jb+1, ia:ib+1] + k21
+        self.Kp[ja:jb+1, ja:jb+1] = self.Kp[ja:jb+1, ja:jb+1] + k22

--- a/OpenSTRAN/Solver.py
+++ b/OpenSTRAN/Solver.py
@@ -92,7 +92,7 @@ class Solver():
                 node_ID_j = submbr.node_j.node_ID
                 i_release = submbr.i_release
                 j_release = submbr.j_release
-                KG = submbr.KG
+                KG = submbr.Kg
                 self.AddMemberToKp(node_ID_i, node_ID_j,
                                    i_release, j_release, KG)
 
@@ -143,7 +143,7 @@ class Solver():
                     ]).T
 
                     submbr.results['displacements'] = np.matmul(
-                        submbr.TM, mbrDisplacements)
+                        submbr.transformation_matrix, mbrDisplacements)
                     forces = np.matmul(
                         submbr.Kl, submbr.results['displacements'])
 
@@ -177,7 +177,7 @@ class Solver():
                     ]).T
 
                     submbr.results['displacements'] = np.matmul(
-                        submbr.TM, mbrDisplacements)
+                        submbr.transformation_matrix, mbrDisplacements)
                     forces = np.matmul(
                         submbr.Kl, submbr.results['displacements'])
 
@@ -209,7 +209,7 @@ class Solver():
                     ]).T
 
                     submbr.results['displacements'] = np.matmul(
-                        submbr.TM, mbrDisplacements)
+                        submbr.transformation_matrix, mbrDisplacements)
                     forces = np.matmul(
                         submbr.Kl, submbr.results['displacements'])
 
@@ -237,7 +237,7 @@ class Solver():
                     ]).T
 
                     submbr.results['displacements'] = np.matmul(
-                        submbr.TM, mbrDisplacements)
+                        submbr.transformation_matrix, mbrDisplacements)
                     forces = np.matmul(
                         submbr.Kl, submbr.results['displacements'])
 

--- a/OpenSTRAN/Submember.py
+++ b/OpenSTRAN/Submember.py
@@ -11,28 +11,41 @@ from typing import Any
 
 @dataclass(slots=True)
 class SubMember():
-    """
-    3D space-frame submember between mesh nodes.
+    """A 3D space-frame submember between mesh nodes.
 
-    A thin wrapper representing a discretized sub-element between two
-    mesh nodes. Contains geometry, section properties, and methods to
-    build local and geometric stiffness matrices.
+    A discretized sub-element between two mesh nodes containing geometry,
+    section properties, and methods to build local and geometric stiffness matrices.
 
-    Attributes:
-        node_i (Node): Start node of the submember.
-        node_j (Node): End node of the submember.
-        i_release (bool): Release (pinned) flag at the start node.
-        j_release (bool): Release (pinned) flag at the end node.
-        E (float): Young's modulus.
-        Ixx (float): Moment of inertia about the strong axis.
-        Iyy (float): Moment of inertia about the weak axis.
-        A (float): Cross-sectional area.
-        G (float): Shear modulus.
-        J (float): Polar moment of inertia.
-        length (float): Submember length (computed).
-        rotation_matrix (np.ndarray): Rotation matrix from local to global.
-        Kl (np.ndarray): Local stiffness matrix.
-        KG (np.ndarray): Global stiffness matrix.
+    :ivar node_i: Start node of the submember
+    :type node_i: Node
+    :ivar node_j: End node of the submember
+    :type node_j: Node
+    :ivar i_release: Release (pinned) flag at the start node
+    :type i_release: bool
+    :ivar j_release: Release (pinned) flag at the end node
+    :type j_release: bool
+    :ivar E: Young's modulus
+    :type E: float
+    :ivar Ixx: Moment of inertia about the strong axis
+    :type Ixx: float
+    :ivar Iyy: Moment of inertia about the weak axis
+    :type Iyy: float
+    :ivar A: Cross-sectional area
+    :type A: float
+    :ivar G: Shear modulus
+    :type G: float
+    :ivar J: Polar moment of inertia
+    :type J: float
+    :ivar length: Submember length (computed)
+    :type length: float
+    :ivar rotation_matrix: Rotation matrix from local to global coordinates
+    :type rotation_matrix: numpy.ndarray
+    :ivar transformation_matrix: Transformation matrix for coordinate conversion
+    :type transformation_matrix: numpy.ndarray
+    :ivar Kl: Local stiffness matrix
+    :type Kl: numpy.ndarray
+    :ivar Kg: Global stiffness matrix
+    :type Kg: numpy.ndarray
     """
     node_i: Node
     node_j: Node
@@ -55,40 +68,21 @@ class SubMember():
     Kg: np.ndarray = field(init=False)
 
     def properties(self) -> dict[str, Any]:
-        """
-        Return all submember properties as a dictionary.
+        """Return all submember properties as a dictionary.
 
         Converts the dataclass instance into a dictionary representation containing
         all field names and their current values.
 
-        :returns: Dictionary containing all member attributes and their values.
+        :returns: Dictionary containing all member attributes and their values
         :rtype: dict[str, Any]
         """
         return asdict(self)
 
     def __post_init__(self) -> None:
-        """Initialize a `SubMember`.
+        """Initialize a SubMember instance.
 
-        :param node_i: Start node of the submember.
-        :type node_i: Node
-        :param node_j: End node of the submember.
-        :type node_j: Node
-        :param i_release: True if the start node is released (pinned).
-        :type i_release: bool
-        :param j_release: True if the end node is released (pinned).
-        :type j_release: bool
-        :param E: Young's modulus.
-        :type E: float
-        :param Ixx: Strong-axis moment of inertia.
-        :type Ixx: float
-        :param Iyy: Weak-axis moment of inertia.
-        :type Iyy: float
-        :param A: Cross-sectional area.
-        :type A: float
-        :param G: Shear modulus.
-        :type G: float
-        :param J: Polar moment of inertia.
-        :type J: float
+        Calculates geometric properties and initializes equivalent nodal actions (ENAs)
+        and results dictionaries.
         """
         self.ENAs = {
             'axial': [0, 0],

--- a/OpenSTRAN/Submember.py
+++ b/OpenSTRAN/Submember.py
@@ -1,35 +1,71 @@
+from .Node import Node
+
 import numpy as np
-import math
+
+from math import sqrt
 
 
 class SubMember():
     """
-    3D Space Frame SubMember Object Between Mesh Nodes
-    <PARAMETERS>
-    node_i: 3D Space Frame Node Object (See Node Class)
-    node_j: 3D Space Frame Node Object (See Node Class)
-    i_release: False = unpinned, True = pinned
-    j_release: False = unpinned, True = pinned
-    E: Young's Modulus [ksi]
-    I: Moment of Inertia [in^4]
-    A: Cross-Sectional Area [in^2]
-    G: Shear Modulus [ksi]
-    J: Polar Moment of Inertia [in^4]
+    3D space-frame submember between mesh nodes.
+
+    A thin wrapper representing a discretized sub-element between two
+    mesh nodes. Contains geometry, section properties, and methods to
+    build local and geometric stiffness matrices.
+
+    Attributes:
+        node_i (Node): Start node of the submember.
+        node_j (Node): End node of the submember.
+        i_release (bool): Release (pinned) flag at the start node.
+        j_release (bool): Release (pinned) flag at the end node.
+        E (float): Young's modulus.
+        Ixx (float): Moment of inertia about the strong axis.
+        Iyy (float): Moment of inertia about the weak axis.
+        A (float): Cross-sectional area.
+        G (float): Shear modulus.
+        J (float): Polar moment of inertia.
+        length (float): Submember length (computed).
+        rotationMatrix (np.ndarray): Rotation matrix from local to global.
+        Kl (np.ndarray): Local stiffness matrix.
+        KG (np.ndarray): Global stiffness matrix.
     """
 
     def __init__(
         self,
-        node_i,
-        node_j,
-        i_release,
-        j_release,
-        E,
-        Ixx,
-        Iyy,
-        A,
-        G,
-        J,
+        node_i: Node,
+        node_j: Node,
+        i_release: bool,
+        j_release: bool,
+        E: float,
+        Ixx: float,
+        Iyy: float,
+        A: float,
+        G: float,
+        J: float,
     ):
+        """Initialize a `SubMember`.
+
+        :param node_i: Start node of the submember.
+        :type node_i: Node
+        :param node_j: End node of the submember.
+        :type node_j: Node
+        :param i_release: True if the start node is released (pinned).
+        :type i_release: bool
+        :param j_release: True if the end node is released (pinned).
+        :type j_release: bool
+        :param E: Young's modulus.
+        :type E: float
+        :param Ixx: Strong-axis moment of inertia.
+        :type Ixx: float
+        :param Iyy: Weak-axis moment of inertia.
+        :type Iyy: float
+        :param A: Cross-sectional area.
+        :type A: float
+        :param G: Shear modulus.
+        :type G: float
+        :param J: Polar moment of inertia.
+        :type J: float
+        """
         self.node_i = node_i
         self.node_j = node_j
         self.i_release = i_release
@@ -48,7 +84,7 @@ class SubMember():
             'minor axis moments': [0, 0],
             'major axis moments': [0, 0]
         }
-        self.results = {
+        self.results: dict[str, list[float]] = {
             'displacements': [],
             'axial': [],
             'shear': [],
@@ -59,21 +95,21 @@ class SubMember():
         }
 
         # calculate the member length based on the node coordinates
-        self.length = self.calculateMbrLength(node_i, node_j)
+        self.length = self.calculate_length(node_i, node_j)
 
         # determine the transformation matrix for the member from the
         # member local coordinates to a global reference frame
-        self.rotationMatrix = self.buildRotationMatrix(
+        self.rotationMatrix = self.build_rotation_matrix(
             node_i,
             node_j,
             i_release,
             j_release
         )
 
-        self.TM = self.rotationMatrix.T
+        self.transformation_matrix = self.rotationMatrix.T
 
         # calculate the member local stiffness matrix
-        self.Kl = self.calculateKl(
+        self.Kl = self.build_stiffness_matrix(
             E,
             Ixx,
             Iyy,
@@ -84,17 +120,47 @@ class SubMember():
         )
 
         # calculate the member global stiffness matrix
-        self.KG = self.TM.T.dot(self.Kl).dot(self.TM)
+        self.KG = self.transformation_matrix.T.dot(
+            self.Kl).dot(self.transformation_matrix)
 
-    def calculateMbrLength(self, node_i, node_j):
+    def calculate_length(self, node_i: Node, node_j: Node) -> float:
+        """
+        Compute Euclidean length between two nodes.
+
+        :param node_i: Start node.
+        :type node_i: Node
+        :param node_j: End node.
+        :type node_j: Node
+        :returns: Length between `node_i` and `node_j`.
+        :rtype: float
+        """
         # calculate the x, y and z vector components of the member
         dx = node_j.coordinates.x - node_i.coordinates.x
         dy = node_j.coordinates.y - node_i.coordinates.y
         dz = node_j.coordinates.z - node_i.coordinates.z
         # calculate and return the member length
-        return (math.sqrt(dx**2 + dy**2 + dz**2))
+        return (sqrt(dx**2 + dy**2 + dz**2))
 
-    def buildRotationMatrix(self, node_i, node_j, i_release, j_release):
+    def build_rotation_matrix(self, node_i: Node, node_j: Node, i_release: bool, j_release: bool) -> np.ndarray:
+        """
+        Build the rotation/transformation matrix for the submember.
+
+        Establishes the local x,y,z unit vectors using a Gram–Schmidt
+        approach and constructs the transformation matrix between the
+        local element frame and the global frame. The size of the
+        returned matrix depends on release conditions.
+
+        :param node_i: Start node.
+        :type node_i: Node
+        :param node_j: End node.
+        :type node_j: Node
+        :param i_release: Release flag at node i.
+        :type i_release: bool
+        :param j_release: Release flag at node j.
+        :type j_release: bool
+        :returns: Transformation matrix mapping local DOFs to global DOFs.
+        :rtype: np.ndarray
+        """
         # assign nodal coordinates to a local variable for readability
         ix = node_i.coordinates.x
         iy = node_i.coordinates.y
@@ -103,9 +169,9 @@ class SubMember():
         jy = node_j.coordinates.y
         jz = node_j.coordinates.z
 
-        # calculate the x, y and z vector components of the member
+        # Calculate the x, y, and z vector components of the member
         dx = jx - ix
-        dy = jy - iy
+        # dy = jy - iy (this does not appear to be used)
         dz = jz - iz
 
         # Check if the member is oriented vertically and, if so, offset
@@ -137,7 +203,7 @@ class SubMember():
         local_y_vector = vector_in_plane - \
             np.dot(vector_in_plane, local_x_unit)*local_x_unit
         # Length of local y-vector
-        magY = math.sqrt(
+        magY = sqrt(
             local_y_vector[0]**2 + local_y_vector[1]**2 + local_y_vector[2]**2)
         # Local unit vector defining the local y-axis
         local_y_unit = local_y_vector/magY
@@ -153,128 +219,45 @@ class SubMember():
         # populate the rotation matrix with the proper values
 
         if i_release == False and j_release == False:
-            TM = np.zeros((12, 12))
-            TM[0:3, 0:3] = rotationMatrix
-            TM[3:6, 3:6] = rotationMatrix
-            TM[6:9, 6:9] = rotationMatrix
-            TM[9:12, 9:12] = rotationMatrix
+            transformation_matrix = np.zeros((12, 12))
+            transformation_matrix[0:3, 0:3] = rotationMatrix
+            transformation_matrix[3:6, 3:6] = rotationMatrix
+            transformation_matrix[6:9, 6:9] = rotationMatrix
+            transformation_matrix[9:12, 9:12] = rotationMatrix
         elif i_release == True and j_release == False:
-            TM = np.zeros((10, 10))
-            TM[0:3, 0:3] = rotationMatrix
-            TM[3, 3] = rotationMatrix[0, 0]
-            TM[4:7, 4:7] = rotationMatrix
-            TM[7:10, 7:10] = rotationMatrix
+            transformation_matrix = np.zeros((10, 10))
+            transformation_matrix[0:3, 0:3] = rotationMatrix
+            transformation_matrix[3, 3] = rotationMatrix[0, 0]
+            transformation_matrix[4:7, 4:7] = rotationMatrix
+            transformation_matrix[7:10, 7:10] = rotationMatrix
         elif i_release == False and j_release == True:
-            TM = np.zeros((10, 10))
-            TM[0:3, 0:3] = rotationMatrix
-            TM[3:6, 3:6] = rotationMatrix
-            TM[6:9, 6:9] = rotationMatrix
-            TM[9, 9] = rotationMatrix[0, 0]
-        elif i_release == True and j_release == True:
-            TM = np.zeros((6, 6))
-            TM[0:3, 0:3] = rotationMatrix
-            TM[3:6, 3:6] = rotationMatrix
+            transformation_matrix = np.zeros((10, 10))
+            transformation_matrix[0:3, 0:3] = rotationMatrix
+            transformation_matrix[3:6, 3:6] = rotationMatrix
+            transformation_matrix[6:9, 6:9] = rotationMatrix
+            transformation_matrix[9, 9] = rotationMatrix[0, 0]
+        else:
+            transformation_matrix = np.zeros((6, 6))
+            transformation_matrix[0:3, 0:3] = rotationMatrix
+            transformation_matrix[3:6, 3:6] = rotationMatrix
 
-        return (TM)
+        return (transformation_matrix)
 
-    def calculateKl(self, E, Izz, Iyy, A, G, J, L):
-        L = float(L*12)
+    def build_stiffness_matrix(self, E: float, Izz: float, Iyy: float, A: float, G: float, J: float, l: float) -> np.ndarray:
+        # Convert units automatically in the future (based on units passed).
+        l = float(l*12)
         if self.i_release == False and self.j_release == False:
             # beam element (fixed at i and j nodes)
-            return (np.array(
+            return np.array(
                 [
                     [
-                        E*A/L,
+                        E*A/l,
                         0,
                         0,
                         0,
                         0,
                         0,
-                        -E*A/L,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ],
-                    [
-                        0,
-                        12*E*Izz/L**3,
-                        0,
-                        0,
-                        0,
-                        6*E*Izz/L**2,
-                        0,
-                        -12*E*Izz/L**3,
-                        0,
-                        0,
-                        0,
-                        6*E*Izz/L**2
-                    ],
-                    [
-                        0,
-                        0,
-                        12*E*Iyy/L**3,
-                        0,
-                        -6*E*Iyy/L**2,
-                        0,
-                        0,
-                        0,
-                        -12*E*Iyy/L**3,
-                        0,
-                        -6*E*Iyy/L**2,
-                        0
-                    ],
-                    [
-                        0,
-                        0,
-                        0,
-                        G*J/L,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        -G*J/L,
-                        0,
-                        0
-                    ],
-                    [
-                        0,
-                        0,
-                        -6*E*Iyy/L**2,
-                        0,
-                        4*E*Iyy/L,
-                        0,
-                        0,
-                        0,
-                        6*E*Iyy/L**2,
-                        0,
-                        2*E*Iyy/L,
-                        0
-                    ],
-                    [
-                        0,
-                        6*E*Izz/L**2,
-                        0,
-                        0,
-                        0,
-                        4*E*Izz/L,
-                        0,
-                        -6*E*Izz/L**2,
-                        0,
-                        0,
-                        0,
-                        2*E*Izz/L
-                    ],
-                    [
-                        -E*A/L,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        E*A/L,
+                        -E*A/l,
                         0,
                         0,
                         0,
@@ -283,134 +266,170 @@ class SubMember():
                     ],
                     [
                         0,
-                        -12*E*Izz/L**3,
+                        12*E*Izz/l**3,
                         0,
                         0,
                         0,
-                        -6*E*Izz/L**2,
+                        6*E*Izz/l**2,
                         0,
-                        12*E*Izz/L**3,
+                        -12*E*Izz/l**3,
                         0,
                         0,
                         0,
-                        -6*E*Izz/L**2
+                        6*E*Izz/l**2
                     ],
                     [
                         0,
                         0,
-                        -12*E*Iyy/L**3,
+                        12*E*Iyy/l**3,
                         0,
-                        6*E*Iyy/L**2,
+                        -6*E*Iyy/l**2,
                         0,
                         0,
                         0,
-                        12*E*Iyy/L**3,
+                        -12*E*Iyy/l**3,
                         0,
-                        6*E*Iyy/L**2,
+                        -6*E*Iyy/l**2,
                         0
                     ],
                     [
                         0,
                         0,
                         0,
-                        -G*J/L,
+                        G*J/l,
                         0,
                         0,
                         0,
                         0,
                         0,
-                        G*J/L,
+                        -G*J/l,
                         0,
                         0
                     ],
                     [
                         0,
                         0,
-                        -6*E*Iyy/L**2,
+                        -6*E*Iyy/l**2,
                         0,
-                        2*E*Iyy/L,
+                        4*E*Iyy/l,
                         0,
                         0,
                         0,
-                        6*E*Iyy/L**2,
+                        6*E*Iyy/l**2,
                         0,
-                        4*E*Iyy/L,
+                        2*E*Iyy/l,
                         0
                     ],
                     [
                         0,
-                        6*E*Izz/L**2,
+                        6*E*Izz/l**2,
                         0,
                         0,
                         0,
-                        2*E*Izz/L,
+                        4*E*Izz/l,
                         0,
-                        -6*E*Izz/L**2,
+                        -6*E*Izz/l**2,
                         0,
                         0,
                         0,
-                        4*E*Izz/L
+                        2*E*Izz/l
+                    ],
+                    [
+                        -E*A/l,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        E*A/l,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ],
+                    [
+                        0,
+                        -12*E*Izz/l**3,
+                        0,
+                        0,
+                        0,
+                        -6*E*Izz/l**2,
+                        0,
+                        12*E*Izz/l**3,
+                        0,
+                        0,
+                        0,
+                        -6*E*Izz/l**2
+                    ],
+                    [
+                        0,
+                        0,
+                        -12*E*Iyy/l**3,
+                        0,
+                        6*E*Iyy/l**2,
+                        0,
+                        0,
+                        0,
+                        12*E*Iyy/l**3,
+                        0,
+                        6*E*Iyy/l**2,
+                        0
+                    ],
+                    [
+                        0,
+                        0,
+                        0,
+                        -G*J/l,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        G*J/l,
+                        0,
+                        0
+                    ],
+                    [
+                        0,
+                        0,
+                        -6*E*Iyy/l**2,
+                        0,
+                        2*E*Iyy/l,
+                        0,
+                        0,
+                        0,
+                        6*E*Iyy/l**2,
+                        0,
+                        4*E*Iyy/l,
+                        0
+                    ],
+                    [
+                        0,
+                        6*E*Izz/l**2,
+                        0,
+                        0,
+                        0,
+                        2*E*Izz/l,
+                        0,
+                        -6*E*Izz/l**2,
+                        0,
+                        0,
+                        0,
+                        4*E*Izz/l
                     ]
-                ]
-            ))
+                ], dtype=float
+            )
         elif self.i_release == True and self.j_release == False:
             # beam element pinned at node i and fixed at node j
-            return (np.array(
+            return np.array(
                 [
                     [
-                        E*A/L,
+                        E*A/l,
                         0,
                         0,
                         0,
-                        -E*A/L,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ],
-                    [
-                        0,
-                        3*E*Izz/L**3,
-                        0,
-                        0,
-                        0,
-                        -3*E*Izz/L**3,
-                        0,
-                        0,
-                        0,
-                        3*E*Izz/L**2
-                    ],
-                    [
-                        0,
-                        0,
-                        3*E*Iyy/L**3,
-                        0,
-                        0,
-                        0,
-                        -3*E*Iyy/L**3,
-                        0,
-                        -3*E*Iyy/L**2,
-                        0
-                    ],
-                    [
-                        0,
-                        0,
-                        0,
-                        G*J/L,
-                        0,
-                        0,
-                        0,
-                        -G*J/L,
-                        0,
-                        0
-                    ],
-                    [
-                        -E*A/L,
-                        0,
-                        0,
-                        0,
-                        E*A/L,
+                        -E*A/l,
                         0,
                         0,
                         0,
@@ -419,227 +438,251 @@ class SubMember():
                     ],
                     [
                         0,
-                        -3*E*Izz/L**3,
+                        3*E*Izz/l**3,
                         0,
                         0,
                         0,
-                        3*E*Izz/L**3,
+                        -3*E*Izz/l**3,
                         0,
                         0,
                         0,
-                        -3*E*Izz/L**2
+                        3*E*Izz/l**2
                     ],
                     [
                         0,
                         0,
-                        -3*E*Iyy/L**3,
+                        3*E*Iyy/l**3,
                         0,
                         0,
                         0,
-                        3*E*Iyy/L**3,
+                        -3*E*Iyy/l**3,
                         0,
-                        3*E*Iyy/L**2,
+                        -3*E*Iyy/l**2,
                         0
                     ],
                     [
                         0,
                         0,
                         0,
-                        -G*J/L,
+                        G*J/l,
                         0,
                         0,
                         0,
-                        G*J/L,
+                        -G*J/l,
+                        0,
+                        0
+                    ],
+                    [
+                        -E*A/l,
+                        0,
+                        0,
+                        0,
+                        E*A/l,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ],
+                    [
+                        0,
+                        -3*E*Izz/l**3,
+                        0,
+                        0,
+                        0,
+                        3*E*Izz/l**3,
+                        0,
+                        0,
+                        0,
+                        -3*E*Izz/l**2
+                    ],
+                    [
+                        0,
+                        0,
+                        -3*E*Iyy/l**3,
+                        0,
+                        0,
+                        0,
+                        3*E*Iyy/l**3,
+                        0,
+                        3*E*Iyy/l**2,
+                        0
+                    ],
+                    [
+                        0,
+                        0,
+                        0,
+                        -G*J/l,
+                        0,
+                        0,
+                        0,
+                        G*J/l,
                         0,
                         0
                     ],
                     [
                         0,
                         0,
-                        -3*E*Iyy/L**2,
+                        -3*E*Iyy/l**2,
                         0,
                         0,
                         0,
-                        3*E*Iyy/L**2,
+                        3*E*Iyy/l**2,
                         0,
-                        3*E*Iyy/L,
+                        3*E*Iyy/l,
                         0
                     ],
                     [
                         0,
-                        3*E*Izz/L**2,
+                        3*E*Izz/l**2,
                         0,
                         0,
                         0,
-                        -3*E*Izz/L**2,
+                        -3*E*Izz/l**2,
                         0,
                         0,
                         0,
-                        3*E*Izz/L
+                        3*E*Izz/l
                     ]
-                ]
-            ))
+                ], dtype=float
+            )
         elif self.i_release == False and self.j_release == True:
             # beam element fixed at node i and pinned at node j
-            return (np.array(
+            return np.array(
                 [
                     [
-                        E*A/L,
+                        E*A/l,
                         0,
                         0,
                         0,
                         0,
                         0,
-                        -E*A/L,
-                        0,
-                        0,
-                        0
-                    ],
-                    [
-                        0,
-                        3*E*Izz/L**3,
-                        0,
-                        0,
-                        0,
-                        3*E*Izz/L**2,
-                        0,
-                        -3*E*Izz/L**3,
-                        0,
-                        0
-                    ],
-                    [
-                        0,
-                        0,
-                        3*E*Iyy/L**3,
-                        0,
-                        -3*E*Iyy/L**2,
-                        0,
-                        0,
-                        0,
-                        -3*E*Iyy/L**3,
-                        0
-                    ],
-                    [
-                        0,
-                        0,
-                        0,
-                        G*J/L,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        -G*J/L
-                    ],
-                    [
-                        0,
-                        0,
-                        -3*E*Iyy/L**2,
-                        0,
-                        3*E*Iyy/L,
-                        0,
-                        0,
-                        0,
-                        3*E*Iyy/L**2,
-                        0
-                    ],
-                    [
-                        0,
-                        3*E*Izz/L**2,
-                        0,
-                        0,
-                        0,
-                        3*E*Izz/L,
-                        0,
-                        -3*E*Izz/L**2,
-                        0,
-                        0
-                    ],
-                    [
-                        -E*A/L,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        E*A/L,
+                        -E*A/l,
                         0,
                         0,
                         0
                     ],
                     [
                         0,
-                        -3*E*Izz/L**3,
+                        3*E*Izz/l**3,
                         0,
                         0,
                         0,
-                        -3*E*Izz/L**2,
+                        3*E*Izz/l**2,
                         0,
-                        3*E*Izz/L**3,
+                        -3*E*Izz/l**3,
                         0,
                         0
                     ],
                     [
                         0,
                         0,
-                        -3*E*Iyy/L**3,
+                        3*E*Iyy/l**3,
                         0,
-                        3*E*Iyy/L**2,
+                        -3*E*Iyy/l**2,
                         0,
                         0,
                         0,
-                        3*E*Iyy/L**3,
+                        -3*E*Iyy/l**3,
                         0
                     ],
                     [
                         0,
                         0,
                         0,
-                        -G*J/L,
+                        G*J/l,
                         0,
                         0,
                         0,
                         0,
                         0,
-                        G*J/L
+                        -G*J/l
+                    ],
+                    [
+                        0,
+                        0,
+                        -3*E*Iyy/l**2,
+                        0,
+                        3*E*Iyy/l,
+                        0,
+                        0,
+                        0,
+                        3*E*Iyy/l**2,
+                        0
+                    ],
+                    [
+                        0,
+                        3*E*Izz/l**2,
+                        0,
+                        0,
+                        0,
+                        3*E*Izz/l,
+                        0,
+                        -3*E*Izz/l**2,
+                        0,
+                        0
+                    ],
+                    [
+                        -E*A/l,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        E*A/l,
+                        0,
+                        0,
+                        0
+                    ],
+                    [
+                        0,
+                        -3*E*Izz/l**3,
+                        0,
+                        0,
+                        0,
+                        -3*E*Izz/l**2,
+                        0,
+                        3*E*Izz/l**3,
+                        0,
+                        0
+                    ],
+                    [
+                        0,
+                        0,
+                        -3*E*Iyy/l**3,
+                        0,
+                        3*E*Iyy/l**2,
+                        0,
+                        0,
+                        0,
+                        3*E*Iyy/l**3,
+                        0
+                    ],
+                    [
+                        0,
+                        0,
+                        0,
+                        -G*J/l,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        G*J/l
                     ]
-                ]
-            ))
-        elif self.i_release == True and self.j_release == True:
+                ], dtype=float
+            )
+        else:
             # bar element (pinned at i and j nodes)
             # returns stiffness matrix in global coordinates
 
-            return (np.array(
+            return np.array(
                 [
                     [
-                        E*A/L,
+                        E*A/l,
                         0,
                         0,
-                        -E*A/L,
-                        0,
-                        0
-                    ],
-                    [
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ],
-                    [
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ],
-                    [
-                        -E*A/L,
-                        0,
-                        0,
-                        E*A/L,
+                        -E*A/l,
                         0,
                         0
                     ],
@@ -659,23 +702,56 @@ class SubMember():
                         0,
                         0
                     ],
-                ]
-            ))
+                    [
+                        -E*A/l,
+                        0,
+                        0,
+                        E*A/l,
+                        0,
+                        0
+                    ],
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ],
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ],
+                ], dtype=float
+            )
 
-    def calculateKG(self):
+    def build_geometric_stiffness_matrix(self) -> np.ndarray:
+        """
+        Compute the geometric (P-Delta) stiffness matrix from results.
+
+        Uses the axial and moment results stored in `self.results` to
+        assemble the geometric stiffness matrix for second-order effects.
+
+        :returns: Geometric stiffness matrix in local element DOFs.
+        :rtype: np.ndarray
+        """
         # define section properties as local variables for readability
         J = self.J
         A = self.A
         L = float(self.length*12)
 
-        # define first order results as local varaibles for readability
-        Fx1 = self.results['axial'][0]
+        # define first-order results as local variables for readability
+        # Fx1 = self.results['axial'][0] # not used?
         Fx2 = self.results['axial'][1]
-        Fy1 = self.results['shear'][0]
-        Fy2 = self.results['shear'][1]
-        Fz1 = self.results['transverse shear'][0]
-        Fz2 = self.results['transverse shear'][1]
-        Mx1 = self.results['torsional moments'][0]
+        # Fy1 = self.results['shear'][0] # not used?
+        # Fy2 = self.results['shear'][1] # not used?
+        # Fz1 = self.results['transverse shear'][0] # not used?
+        # Fz2 = self.results['transverse shear'][1] # not used?
+        # Mx1 = self.results['torsional moments'][0] # not used
         Mx2 = self.results['torsional moments'][1]
         My1 = self.results['minor axis moments'][0]
         My2 = self.results['minor axis moments'][1]
@@ -683,7 +759,7 @@ class SubMember():
         Mz2 = self.results['major axis moments'][1]
 
         # beam element (fixed at i and j nodes)
-        return (np.array(
+        return np.array(
             [
                 [
                     Fx2/L,
@@ -853,5 +929,5 @@ class SubMember():
                     0,
                     2*Fx2*L/15
                 ]
-            ]
-        ))
+            ], dtype=float
+        )

--- a/OpenSTRAN/__init__.py
+++ b/OpenSTRAN/__init__.py
@@ -1,0 +1,7 @@
+"""OpenSTRAN - Open-source Structural Analysis Package.
+
+A Python package for 3D finite element analysis of space frames.
+This package provides tools for structural modeling and analysis.
+"""
+
+__version__ = "0.1.0"

--- a/OpenSTRAN/model.py
+++ b/OpenSTRAN/model.py
@@ -48,7 +48,7 @@ class Model():
         Rmz = []
 
         for node in self.nodes.nodes.values():
-            if node.meshNode != False:
+            if node.mesh_node != False:
                 Rx.append(node.Rx)
                 Ry.append(node.Ry)
                 Rz.append(node.Rz)
@@ -169,8 +169,8 @@ class Model():
     def reactions(self):
         print('Nodal Reactions')
         for node in self.nodes.nodes.values():
-            if node.meshNode != True:
-                print(f'\tNode {node.nodeID}:')
+            if node.mesh_node != True:
+                print(f'\tNode {node.node_ID}:')
                 print(f'\t\tRx = {node.Rx:.2f} kips')
                 print(f'\t\tRy = {node.Ry:.2f} kips')
                 print(f'\t\tRz = {node.Rz:.2f} kips')

--- a/OpenSTRAN/model.py
+++ b/OpenSTRAN/model.py
@@ -7,45 +7,82 @@ from .Solver import Solver
 
 class Model():
     """
-    3D Space Frame Model
+    3D space frame structural model.
 
-    The model neglects deformations due to transverse shear stresses
-    and torsional warping. The model does not account for such
-    deformations under the premise that torsional effects are generally
-    negligible in typical civil engineering practice.
+    This class represents a three-dimensional space frame for finite element analysis.
+    The model neglects deformations due to transverse shear stresses and torsional warping,
+    operating under the assumption that such effects are negligible in typical civil
+    engineering applications.
 
-    OPTIONAL PARAMETERS:
-    plane = 'xy' - defines a model constrained to the X-Y plane
-    plane = 'yz' - defines a model constrained to the Y-Z plane
-    plane = 'xz' - defines a model constrained to the X-Z plane
+    :param plane: Constrains the model to a two-dimensional plane. Valid values are 'xy',
+        'yz', or 'xz'. If None, the model is fully three-dimensional.
+    :type plane: str | None
+    :ivar nodes: Collection of nodes in the structure
+    :type nodes: Nodes
+    :ivar members: Collection of members (elements) in the structure
+    :type members: Members
+    :ivar solver: Solver instance for performing structural analysis
+    :type solver: Solver
 
-    no definition of a plane indicates the model is not restrained to a
-    two-dimensional plane.
+    :Example:
 
-    USAGE:
-
-    import OpenStruct
-    2Dframe = OpenStruct.Model(plane='xy')
-    3Dframe = OpenStruct.Model()
+        >>> import OpenSTRAN
+        >>> frame_2d = OpenSTRAN.Model(plane='xy')
+        >>> frame_3d = OpenSTRAN.Model()
     """
 
-    def __init__(self, plane=None):
+    def __init__(self, plane: str | None = None) -> None:
+        """
+        Initialize a structural model.
+
+        :param plane: Plane constraint for 2D models ('xy', 'yz', or 'xz').
+            Defaults to None for 3D models.
+        :type plane: str | None
+        """
         self.nodes = Nodes(plane)
         self.members = Members(self.nodes)
         self.solver = Solver()
 
-    def solve(self):
+    def solve(self) -> None:
+        """Solve the structural system and compute reactions and member forces.
+
+        This method performs a complete finite element analysis including:
+        
+        - Assembly and solution of the global stiffness system
+        - Calculation of nodal reactions at restrained DOFs
+        - Determination of member forces and local extrema
+
+        :returns: None
+        :rtype: None
+        """
         self.solver.solve(self.nodes, self.members)
         self.maxReactions()
         self.maxMbrForces()
 
-    def maxReactions(self):
-        Rx = []
-        Ry = []
-        Rz = []
-        Rmx = []
-        Rmy = []
-        Rmz = []
+    def maxReactions(self) -> None:
+        """Calculate maximum reaction forces and moments at restrained nodes.
+
+        Computes the maximum absolute values of reaction forces and moments
+        across all support nodes in the structure.
+
+        :returns: None
+        :rtype: None
+        
+        Sets the following instance attributes:
+        
+        - Rx_max: Maximum X-direction reaction force
+        - Ry_max: Maximum Y-direction reaction force
+        - Rz_max: Maximum Z-direction reaction force
+        - Rmx_max: Maximum X-direction reaction moment
+        - Rmy_max: Maximum Y-direction reaction moment
+        - Rmz_max: Maximum Z-direction reaction moment
+        """
+        Rx: list[float] = []
+        Ry: list[float] = []
+        Rz: list[float] = []
+        Rmx: list[float] = []
+        Rmy: list[float] = []
+        Rmz: list[float] = []
 
         for node in self.nodes.nodes.values():
             if node.mesh_node != False:
@@ -63,13 +100,31 @@ class Model():
         self.Rmy_max = abs(max(Rmy, key=lambda x: abs(x)))
         self.Rmz_max = abs(max(Rmz, key=lambda x: abs(x)))
 
-    def maxMbrForces(self):
-        axial = []
-        torque = []
-        Vy = []
-        Vz = []
-        Mzz = []
-        Myy = []
+    def maxMbrForces(self) -> None:
+        """Calculate maximum member forces and identify local extrema.
+
+        Computes the maximum values for all member internal forces (axial, shear, torsion,
+        and bending moments) and identifies their local maxima and minima distributions
+        along members.
+
+        :returns: None
+        :rtype: None
+        
+        Sets the following instance attributes:
+        
+        - axial_max, axial_maxima, axial_minima: Axial force results
+        - torque_max, torque_maxima, torque_minima: Torsional moment results
+        - Vy_max, Vy_maxima, Vy_minima: Y-direction shear force results
+        - Vz_max, Vz_maxima, Vz_minima: Z-direction shear force results
+        - Mzz_max, Mzz_maxima, Mzz_minima: Major axis bending moment results
+        - Myy_max, Myy_maxima, Myy_minima: Minor axis bending moment results
+        """
+        axial: list[float] = []
+        torque: list[float] = []
+        Vy: list[float] = []
+        Vz: list[float] = []
+        Mzz: list[float] = []
+        Myy: list[float] = []
 
         for mbr in self.members.members.values():
             for submbr in mbr.submembers.values():
@@ -110,8 +165,19 @@ class Model():
         self.Myy_maxima = self.localMaxima(Myy)
         self.Myy_minima = self.localMinima(Myy)
 
-    def localMaxima(self, forces):
-        maxima = [False for force in forces]
+    def localMaxima(self, forces: list[float]) -> list[bool]:
+        """Identify local maxima in a force distribution.
+
+        Determines which points in the force distribution represent local maxima
+        by comparing adjacent values, accounting for numerical precision with
+        near-equal comparisons.
+
+        :param forces: List of force values along a member or structure
+        :type forces: list[float]
+        :returns: Boolean list indicating local maxima positions
+        :rtype: list[bool]
+        """
+        maxima = [False for _ in forces]
         length = len(forces)-1
         for i, force in enumerate(forces):
             if i == 0:
@@ -138,8 +204,19 @@ class Model():
                     continue
         return (maxima)
 
-    def localMinima(self, forces):
-        minima = [False for force in forces]
+    def localMinima(self, forces: list[float]) -> list[bool]:
+        """Identify local minima in a force distribution.
+
+        Determines which points in the force distribution represent local minima
+        by comparing adjacent values, accounting for numerical precision with
+        near-equal comparisons.
+
+        :param forces: List of force values along a member or structure
+        :type forces: list[float]
+        :returns: Boolean list indicating local minima positions
+        :rtype: list[bool]
+        """
+        minima = [False for _ in forces]
         length = len(forces)-1
         for i, force in enumerate(forces):
             if i == 0:
@@ -166,7 +243,15 @@ class Model():
                     continue
         return (minima)
 
-    def reactions(self):
+    def reactions(self) -> None:
+        """Print nodal reactions to console.
+
+        Displays all reaction forces (Rx, Ry, Rz) and reaction moments (Mx, My, Mz)
+        at all restrained support nodes in a formatted table.
+
+        :returns: None
+        :rtype: None
+        """
         print('Nodal Reactions')
         for node in self.nodes.nodes.values():
             if node.mesh_node != True:

--- a/test.py
+++ b/test.py
@@ -5,10 +5,10 @@ import time
 simpleBeam = Model()
 
 # create a node located at the origin
-N1 = simpleBeam.nodes.addNode(0, 0, 0, 'N1')  # (X [ft], Y [ft], Z[ft], name)
+N1 = simpleBeam.nodes.add_node(0, 0, 0)  # (X [ft], Y [ft], Z[ft])
 
 # create a node 10 feet away from the origin along the global X axis.
-N2 = simpleBeam.nodes.addNode(10, 0, 0, 'N2')  # (X [ft], Y [ft], Z[ft], name)
+N2 = simpleBeam.nodes.add_node(10, 0, 0)  # (X [ft], Y [ft], Z[ft])
 
 # restrain the nodes from translation.
 N1.restraint = [1, 1, 1, 0, 0, 0]  # [Ux, Uy, Uz, φx, φy, φz] -> pinned node
@@ -18,7 +18,7 @@ N2.restraint = [1, 1, 1, 0, 0, 0]  # [Ux, Uy, Uz, φx, φy, φz] -> pinned node
 M1 = simpleBeam.members.addMember(N1, N2, mesh=50)  # (i node, j node)
 
 # add a load of -1 kips in the global Y direction along M1's span.
-M1.addTrapLoad(-1, -1, 'Y', 0, 100)
+M1.add_distributed_load(-1, -1, 'Y', 0, 100)
 
 # print(simpleBeam.nodes.properties())
 
@@ -27,7 +27,7 @@ start = time.time()
 simpleBeam.solve()
 stop = time.time()
 
-print(f"time to run: {stop-start} seconds")
+print(f"time to run: {stop-start:2f} seconds")
 
 # print the nodal reactions to the terminal.
 # simpleBeam.reactions()

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 from OpenSTRAN.Model import Model
+import time
 
 # instantiate an empty model
 simpleBeam = Model()
@@ -14,13 +15,19 @@ N1.restraint = [1, 1, 1, 0, 0, 0]  # [Ux, Uy, Uz, φx, φy, φz] -> pinned node
 N2.restraint = [1, 1, 1, 0, 0, 0]  # [Ux, Uy, Uz, φx, φy, φz] -> pinned node
 
 # define a member between nodes N1 and N2.
-M1 = simpleBeam.members.addMember(N1, N2)  # (i node, j node)
+M1 = simpleBeam.members.addMember(N1, N2, mesh=50)  # (i node, j node)
 
 # add a load of -1 kips in the global Y direction along M1's span.
 M1.addTrapLoad(-1, -1, 'Y', 0, 100)
 
+# print(simpleBeam.nodes.properties())
+
+start = time.time()
 # solve the model.
 simpleBeam.solve()
+stop = time.time()
+
+print(f"time to run: {stop-start} seconds")
 
 # print the nodal reactions to the terminal.
-simpleBeam.reactions()
+# simpleBeam.reactions()


### PR DESCRIPTION
## Standardize Docstrings

- Updated all existing docstrings to follow consistent **Sphinx-style** formatting.
- Reviewed and corrected comments for spelling, grammar, and syntax.
- Missing docstrings added to all methods.

## Added Type Hints

- Added comprehensive type hints across all files.
-Code now conforms to **Pylance strict** type-checking requirements.

## Implemented Dataclasses

- Refactored data-heavy classes to use `@dataclass` for clarity and reduced boilerplate.
- Affected classes:
  - `Nodes`
  - `Node`
  - `Coordinates`
  - `Members`
  - `Member`
  - `Submember`

- Enabled `slots=True` to reduce memory overhead and prevent accidental attribute creation.